### PR TITLE
Use latest guzzlehttp/command to fix dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/command": "0.1.*"
+        "guzzlehttp/command": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*"


### PR DESCRIPTION
Hi, this change is intended to fix composer installation of guzzlehttp/guzzle-services "dev-master"

Basically version 0.1.0 of guzzlehttp/command is missing some new classes used in guzzle-services dev-master
