### PR TITLE
Fixed string zero ('0') values not being filtered in XML.

### DIFF
--- a/src/ResponseLocation/XmlLocation.php
+++ b/src/ResponseLocation/XmlLocation.php
@@ -93,7 +93,7 @@ class XmlLocation extends AbstractLocation
         }
 
         // Filter out the value
-        if ($result) {
+        if (isset($result)) {
             $result = $param->filter($result);
         }
 


### PR DESCRIPTION
If a XML response returns a '0' value then the parameter filters do not get ran.

Changed to using isset() instead of standard boolean check.
