### PR TITLE
Fix 'Invalid argument supplied for foreach()'

### DIFF
--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -21,7 +21,7 @@ class JsonLocation extends AbstractLocation
         &$result,
         array $context = []
     ) {
-        $this->json = $response->json();
+        $this->json = $response->json() ?: [];
     }
 
     public function after(

--- a/tests/ResponseLocation/JsonLocationTest.php
+++ b/tests/ResponseLocation/JsonLocationTest.php
@@ -51,6 +51,21 @@ class JsonLocationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([1, 2], $result['qux']);
     }
 
+    public function testVisitsAdditionalPropertiesWithEmptyResponse()
+    {
+        $l = new JsonLocation('json');
+        $operation = new Operation([], new Description([]));
+        $command = new Command($operation, []);
+        $parameter = new Parameter();
+        $model = new Parameter(['additionalProperties' => ['location' => 'json']]);
+        $response = new Response(204);
+        $result = [];
+        $l->before($command, $response, $parameter, $result);
+        $l->visit($command, $response, $parameter, $result);
+        $l->after($command, $response, $model, $result);
+        $this->assertEquals([], $result);
+    }
+
     public function jsonProvider()
     {
         return [


### PR DESCRIPTION
This warning appears in ResponseLocation\JsonLocation:36 when response body is empty.

Tests fail in hhvm environment not only on my branch so as on master. In other environments they pass.
