### PR TITLE
Allow extension to work recursively over models

### DIFF
--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -153,7 +153,7 @@ class Parameter implements ToArrayInterface
                 // with the actual data union in the parent's data (e.g. actual
                 // supersedes parent)
                 if ($extends = $this->serviceDescription->getModel($data['extends'])) {
-                    $data += $extends->toArray();
+                    $data = array_merge_recursive($data, $extends->toArray());
                 }
             }
         }

--- a/tests/ParameterTest.php
+++ b/tests/ParameterTest.php
@@ -255,6 +255,31 @@ class ParameterTest extends \PHPUnit_Framework_TestCase
         ), $p->toArray());
     }
 
+    public function testExtendedModelsAreDeeplyMerged()
+    {
+        $quiGon = [
+            'type' => 'object',
+            'properties' => [
+                'lightSaber' => ['enum' => ['red', 'green', 'blue'], 'default' => 'green']
+            ]
+        ];
+
+        $obiWan = [
+            'extends' => 'QuiGon',
+            'properties' => [
+                'jediType' => ['enum' => ['youngling', 'padawan', 'knight', 'master']]
+            ]
+        ];
+
+        $description = new Description([
+            'models' => ['QuiGon' => $quiGon, 'ObiWan' => $obiWan]
+        ]);
+
+        $obiModel = $description->getModel('ObiWan');
+        $this->assertEquals('master', $obiModel->getProperty('jediType')->getEnum()[3]);
+        $this->assertEquals('green', $obiModel->getProperty('lightSaber')->getDefault());
+    }
+
     public function testHasKeyMethod()
     {
         $p = new Parameter(['name' => 'foo', 'sentAs' => 'bar']);


### PR DESCRIPTION
Currently, when a model extends another one, a shallow union is performed. The problem is that nested elements inside the parent model (like its `properties`) are not merged into the current one. Is this what you intended? If not, does this PR look alright?
