### PR TITLE
added description interface to extend it

### DIFF
--- a/src/Description.php
+++ b/src/Description.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Url;
 /**
  * Represents a Guzzle service description
  */
-class Description
+class Description implements DescriptionInterface
 {
     /** @var array Array of {@see OperationInterface} objects */
     private $operations = [];

--- a/src/DescriptionInterface.php
+++ b/src/DescriptionInterface.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace GuzzleHttp\Command\Guzzle;
+
+use GuzzleHttp\Url;
+
+interface DescriptionInterface
+{
+    /**
+     * Get the basePath/baseUrl of the description
+     *
+     * @return Url
+     */
+    public function getBaseUrl();
+
+    /**
+     * Get the API operations of the service
+     *
+     * @return Operation[] Returns an array of {@see Operation} objects
+     */
+    public function getOperations();
+
+    /**
+     * Check if the service has an operation by name
+     *
+     * @param string $name Name of the operation to check
+     *
+     * @return bool
+     */
+    public function hasOperation($name);
+
+    /**
+     * Get an API operation by name
+     *
+     * @param string $name Name of the command
+     *
+     * @return Operation
+     * @throws \InvalidArgumentException if the operation is not found
+     */
+    public function getOperation($name);
+
+    /**
+     * Get a shared definition structure.
+     *
+     * @param string $id ID/name of the model to retrieve
+     *
+     * @return Parameter
+     * @throws \InvalidArgumentException if the model is not found
+     */
+    public function getModel($id);
+
+    /**
+     * Get all models of the service description.
+     *
+     * @return array
+     */
+    public function getModels();
+
+    /**
+     * Check if the service description has a model by name.
+     *
+     * @param string $id Name/ID of the model to check
+     *
+     * @return bool
+     */
+    public function hasModel($id);
+    
+    /**
+     * Get the API version of the service
+     *
+     * @return string
+     */
+    public function getApiVersion();
+
+    /**
+     * Get the name of the API
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Get a summary of the purpose of the API
+     *
+     * @return string
+     */
+    public function getDescription();
+
+    /**
+     * Format a parameter using named formats.
+     *
+     * @param string $format Format to convert it to
+     * @param mixed  $input  Input string
+     *
+     * @return mixed
+     */
+    public function format($format, $input);
+
+    /**
+     * Get arbitrary data from the service description that is not part of the
+     * Guzzle service description specification.
+     *
+     * @param string $key Data key to retrieve or null to retrieve all extra
+     *
+     * @return null|mixed
+     */
+    public function getData($key = null);
+
+} 

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -37,13 +37,13 @@ class GuzzleClient extends AbstractClient implements GuzzleClientInterface
      * - response_locations: Associative array of location types mapping to
      *   ResponseLocationInterface objects.
      *
-     * @param ClientInterface   $client      Client used to send HTTP requests
-     * @param Description       $description Guzzle service description
-     * @param array             $config      Configuration options
+     * @param ClientInterface        $client      Client used to send HTTP requests
+     * @param DescriptionInterface   $description Guzzle service description
+     * @param array                  $config      Configuration options
      */
     public function __construct(
         ClientInterface $client,
-        Description $description,
+        DescriptionInterface $description,
         array $config = []
     ) {
         parent::__construct($client, $config);
@@ -73,11 +73,11 @@ class GuzzleClient extends AbstractClient implements GuzzleClientInterface
      * Creates a callable function used to create command objects from a
      * service description.
      *
-     * @param Description $description Service description
+     * @param DescriptionInterface $description Service description
      *
      * @return callable Returns a command factory
      */
-    public static function defaultCommandFactory(Description $description)
+    public static function defaultCommandFactory(DescriptionInterface $description)
     {
         return function (
             $name,

--- a/src/GuzzleClientInterface.php
+++ b/src/GuzzleClientInterface.php
@@ -12,7 +12,7 @@ interface GuzzleClientInterface extends ServiceClientInterface
     /**
      * Returns the service description used by the client
      *
-     * @return Description
+     * @return DescriptionInterface
      */
     public function getDescription();
 }

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -45,11 +45,11 @@ class Operation implements ToArrayInterface
      * - additionalParameters: (null|array) Parameter schema to use when an
      *   option is passed to the operation that is not in the schema
      *
-     * @param array             $config      Array of configuration data
-     * @param Description $description Service description used to resolve models if $ref tags are found
+     * @param array                 $config      Array of configuration data
+     * @param DescriptionInterface  $description Service description used to resolve models if $ref tags are found
      * @throws \InvalidArgumentException
      */
-    public function __construct(array $config = [], Description $description)
+    public function __construct(array $config = [], DescriptionInterface $description)
     {
         static $defaults = [
             'name' => '',

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -137,7 +137,7 @@ class Parameter implements ToArrayInterface
 
         if (isset($options['description'])) {
             $this->serviceDescription = $options['description'];
-            if (!($this->serviceDescription instanceof Description)) {
+            if (!($this->serviceDescription instanceof DescriptionInterface)) {
                 throw new \InvalidArgumentException('description must be a Description');
             }
             if (isset($data['$ref'])) {


### PR DESCRIPTION
I've added an interface at the Description object and changed as protected its attribute.
I do that because in this way it's allowed to extend the description object. For example if I want to add a different way to fetch the operation, I can pass as an option another method for "defaultCommandFactory" that will receive my custom Description object that implements the DescriptionInterface.
