### PR TITLE
Throw Any Exceptions On Process

### DIFF
--- a/src/Subscriber/ProcessResponse.php
+++ b/src/Subscriber/ProcessResponse.php
@@ -67,6 +67,10 @@ class ProcessResponse implements SubscriberInterface
 
     public function onProcess(ProcessEvent $event)
     {
+        if ($exception = $event->getException()) {
+            throw $exception;
+        }
+
         $command = $event->getCommand();
 
         // Do not overwrite a previous result


### PR DESCRIPTION
This fixes both #58 and #57.

In #57, the issue was that everything was silently failing because there was an exception that caused there to be no response object, later resulting in a php fatal error.

In #58, the issue is that an exception has been thrown that means that the response is not valid, so we should bail out, and not try to generate a model, but we went ahead, and did it anyway - not desirable.
