### PR TITLE
Gracefully handle null return from $this->getConfig('defaults')

### DIFF
--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -68,8 +68,9 @@ class GuzzleClient extends AbstractClient
             $future = false;
         }
 
-        // Merge in default command options
-        $args += $this->getConfig('defaults');
+		// Merge in default command options
+		$defaults = $this->getConfig('defaults') ?: [];
+        $args += $defaults;
 
         if ($command = $factory($name, $args, $this)) {
             $command->setFuture($future);

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -68,8 +68,8 @@ class GuzzleClient extends AbstractClient
             $future = false;
         }
 
-		// Merge in default command options
-		$defaults = $this->getConfig('defaults') ?: [];
+        // Merge in default command options
+        $defaults = $this->getConfig('defaults') ?: [];
         $args += $defaults;
 
         if ($command = $factory($name, $args, $this)) {


### PR DESCRIPTION
This resolves an "unsupported operand types" error.

Either this or guzzle/command#26 will resolve the issue, I'm leaving it up to the upstream authors to decide which approach is more appropriate since the return type of `getConfig()` is a design decision.