### PR TITLE
fix description for get request example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,14 +16,10 @@ Provides an implementation of the Guzzle Command library that uses Guzzle servic
         'operations' => [
             'testing' => [
                 'httpMethod' => 'GET',
-                'uri' => '/get/{foo}',
+                'uri' => 'get',
                 'responseModel' => 'getResponse',
                 'parameters' => [
                     'foo' => [
-                        'type' => 'string',
-                        'location' => 'uri'
-                    ],
-                    'bar' => [
                         'type' => 'string',
                         'location' => 'query'
                     ]


### PR DESCRIPTION
GET request used in example should be http://httpbin.org/get?foo=bar