### PR TITLE
Allow mapping null response values to defined response model properties

### DIFF
--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -109,7 +109,7 @@ class JsonLocation extends AbstractLocation
             if ($properties = $param->getProperties()) {
                 foreach ($properties as $property) {
                     $key = $property->getWireName();
-                    if (isset($value[$key])) {
+                    if (array_key_exists($key, $value)) {
                         $result[$property->getName()] = $this->recurse(
                             $property,
                             $value[$key]


### PR DESCRIPTION
This pull request is in response to #91 

It basically allows mapping null response values to defines model properties.
