### PR TITLE
Bug Fix for GuzzleClient constructor

### DIFF
--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -142,6 +142,11 @@ class GuzzleClient extends AbstractClient
      */
     protected function processConfig(array $config)
     {
+        // set defaults as an array if not provided
+        if (!isset($config['defaults'])) {
+            $config['defaults'] = [];
+        }
+        
         // Use the passed in command factory or a custom factory if provided
         $this->commandFactory = isset($config['command_factory'])
             ? $config['command_factory']


### PR DESCRIPTION
Adds the 'defaults' key as an array on the config constructor argument which stops a fatal error occurring on src/GuzzleClient.php on line 72 when getting the config's defaults key returns null.