### PR TITLE
Fixing JsonLocation::visit() not returning a request #106

### DIFF
--- a/src/RequestLocation/JsonLocation.php
+++ b/src/RequestLocation/JsonLocation.php
@@ -38,6 +38,9 @@ class JsonLocation extends AbstractLocation
             $command[$param->getName()],
             $param
         );
+        // Returning unchanged request, because Serializer::prepareRequest()
+        // requires a return.
+        return $request;
     }
 
     public function after(


### PR DESCRIPTION
in guzzle6, Serialize::prepareRequest() calls visit() but it expects a RequestInterface that goes to replace the one passed to the method. The visit() implementation of JsonLocation only writes to $this->jsonData and doesn't return anything, so the origina request is replaced with null.