### PR TITLE
Fix serialization of query params

### DIFF
--- a/src/RequestLocation/QueryLocation.php
+++ b/src/RequestLocation/QueryLocation.php
@@ -42,7 +42,7 @@ class QueryLocation extends AbstractLocation
             $param
         );
 
-        $uri = $uri->withQuery(Psr7\build_query($query));
+        $uri = $uri->withQuery(http_build_query($query, null, '&', PHP_QUERY_RFC3986));
 
         return $request->withUri($uri);
     }
@@ -71,7 +71,7 @@ class QueryLocation extends AbstractLocation
                         $additional
                     );
 
-                    $uri = $uri->withQuery(Psr7\build_query($query));
+                    $uri = $uri->withQuery(http_build_query($query, null, '&', PHP_QUERY_RFC3986));
                     $request = $request->withUri($uri);
                 }
             }


### PR DESCRIPTION
Addresses #128 

This PR is likely a BC of 1, but as the behaviour of 1.0.0 is wrong and completely different from previous version, I think it's more a bug fix rather than a BC. Also there was no test to verify this behaviour.

Currently, the Guzzle Service serializes incorrectly any query params that are array or object.

For instance, considering this operation's param:

```php
'foo' => [
  'type' => 'array',
  'location' => 'query'
]
```

Specifying this parameter: $client->myOperation(['foo' => [1, 2]]) would serialize this query parameter : foo=1&foo=2, which is completely different from the older behaviour and, from my understanding, incorrect.

Similarily, when specifying an object type, this: $client->myOperation(['foo' => ['bar' => 'baz']]) would serialize this query "foo=baz" (hence completely loosing the context of bar).

After this PR, first operation would be serialized 'foo[0]=1&foo[1]=2' and second operation would be serialized 'foo[bar]=baz'.

Thanks a lot!