### PR TITLE
Allow to fix validation for parameters with a format

### DIFF
--- a/src/Handler/ValidatedDescriptionHandler.php
+++ b/src/Handler/ValidatedDescriptionHandler.php
@@ -41,7 +41,11 @@ class ValidatedDescriptionHandler
             $operation = $this->description->getOperation($command->getName());
 
             foreach ($operation->getParams() as $name => $schema) {
-                $value = $schema->filter($command[$name]);
+                $value = $command[$name];
+
+                if ($value) {
+                    $value = $schema->filter($value);
+                }
 
                 if (! $this->validator->validate($schema, $value)) {
                     $errors = array_merge($errors, $this->validator->getErrors());

--- a/src/Handler/ValidatedDescriptionHandler.php
+++ b/src/Handler/ValidatedDescriptionHandler.php
@@ -41,7 +41,8 @@ class ValidatedDescriptionHandler
             $operation = $this->description->getOperation($command->getName());
 
             foreach ($operation->getParams() as $name => $schema) {
-                $value = $command[$name];
+                $value = $schema->filter($command[$name]);
+
                 if (! $this->validator->validate($schema, $value)) {
                     $errors = array_merge($errors, $this->validator->getErrors());
                 } elseif ($value !== $command[$name]) {

--- a/src/SchemaFormatter.php
+++ b/src/SchemaFormatter.php
@@ -53,7 +53,7 @@ class SchemaFormatter
             $dateTime = new \DateTime($dateTime);
         }
 
-        if ($dateTime instanceof \DateTime) {
+        if ($dateTime instanceof \DateTimeInterface) {
             static $utc;
             if (!$utc) {
                 $utc = new \DateTimeZone('UTC');

--- a/tests/Handler/ValidatedDescriptionHandlerTest.php
+++ b/tests/Handler/ValidatedDescriptionHandlerTest.php
@@ -94,9 +94,9 @@ class ValidatedDescriptionHandlerTest extends \PHPUnit_Framework_TestCase
                 'foo' => [
                     'uri' => 'http://httpbin.org',
                     'httpMethod' => 'GET',
-                    'responseModel' => 'j',
                     'parameters' => [
                         'bar' => [
+                            'location' => 'uri',
                             'type'     => 'string',
                             'format'   => 'date-time',
                             'required' => true

--- a/tests/Handler/ValidatedDescriptionHandlerTest.php
+++ b/tests/Handler/ValidatedDescriptionHandlerTest.php
@@ -86,4 +86,27 @@ class ValidatedDescriptionHandlerTest extends \PHPUnit_Framework_TestCase
         $client = new GuzzleClient(new HttpClient(), $description);
         $client->foo(['bar' => new \stdClass()]);
     }
+
+    public function testFilterBeforeValidate()
+    {
+        $description = new Description([
+            'operations' => [
+                'foo' => [
+                    'uri' => 'http://httpbin.org',
+                    'httpMethod' => 'GET',
+                    'responseModel' => 'j',
+                    'parameters' => [
+                        'bar' => [
+                            'type'     => 'string',
+                            'format'   => 'date-time',
+                            'required' => true
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $client = new GuzzleClient(new HttpClient(), $description);
+        $client->foo(['bar' => new \DateTimeImmutable()]); // Should not throw any exception
+    }
 }


### PR DESCRIPTION
Hi !

Some parameters may have a given type (example: string) in conjunction of a format (such as "date-time").

Currently, passing a DateTime for instance to such fields throw a validation error, because the format is done _after_ validating it. As such conversion change the type of the value (DateTime => string), this PR ensures that this conversion is done before validating.