### PR TITLE
Bring more flexibility to query params serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,31 @@ The request locations `postField` and `postFile` were removed in favor of `formP
 you need to change `postField` to `formParam` and `postFile` to `multipart`. 
 
 More documentation coming soon.
+
+## Cookbook
+
+### Changing the way query params are serialized
+
+By default, query params are serialized using strict RFC3986 rules, using `http_build_query` method. With this, array params are serialized this way:
+
+```php
+$client->myMethod(['foo' => ['bar', 'baz']]);
+
+// Query params will be foo[0]=bar&foo[1]=baz
+```
+
+However, a lot of APIs in the wild require the numeric indices to be removed, so that the query params end up being `foo[]=bar&foo[]=baz`. You
+can easily change the behaviour by creating your own serializer and overriding the "query" request location:
+
+```php
+use GuzzleHttp\Command\Guzzle\GuzzleClient;
+use GuzzleHttp\Command\Guzzle\RequestLocation\QueryLocation;
+use GuzzleHttp\Command\Guzzle\QuerySerializer\Rfc3986Serializer;
+use GuzzleHttp\Command\Guzzle\Serializer;
+
+$queryLocation   = new QueryLocation('query', new Rfc3986Serializer(true));
+$serializer      = new Serializer($description, ['query' => $queryLocation]);
+$guzzleClient    = new GuzzleClient($client, $description, $serializer);
+```
+
+You can also create your own serializer if you have specific needs.

--- a/src/QuerySerializer/QuerySerializerInterface.php
+++ b/src/QuerySerializer/QuerySerializerInterface.php
@@ -1,0 +1,13 @@
+<?php
+namespace GuzzleHttp\Command\Guzzle\QuerySerializer;
+
+interface QuerySerializerInterface
+{
+    /**
+     * Aggregate query params and transform them into a string
+     *
+     * @param  array $queryParams
+     * @return string
+     */
+    public function aggregate(array $queryParams);
+}

--- a/src/QuerySerializer/Rfc3986Serializer.php
+++ b/src/QuerySerializer/Rfc3986Serializer.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace GuzzleHttp\Command\Guzzle\QuerySerializer;
+
+class Rfc3986Serializer implements QuerySerializerInterface
+{
+    /**
+     * @var bool
+     */
+    private $removeNumericIndices;
+
+    /**
+     * @param bool $removeNumericIndices
+     */
+    public function __construct($removeNumericIndices = false)
+    {
+        $this->removeNumericIndices = $removeNumericIndices;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function aggregate(array $queryParams)
+    {
+        $queryString = http_build_query($queryParams, null, '&', PHP_QUERY_RFC3986);
+
+        if ($this->removeNumericIndices) {
+            $queryString = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $queryString);
+        }
+
+        return $queryString;
+    }
+}

--- a/src/RequestLocation/QueryLocation.php
+++ b/src/RequestLocation/QueryLocation.php
@@ -4,6 +4,8 @@ namespace GuzzleHttp\Command\Guzzle\RequestLocation;
 use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
+use GuzzleHttp\Command\Guzzle\QuerySerializer\QuerySerializerInterface;
+use GuzzleHttp\Command\Guzzle\QuerySerializer\Rfc3986Serializer;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\RequestInterface;
 
@@ -13,13 +15,21 @@ use Psr\Http\Message\RequestInterface;
 class QueryLocation extends AbstractLocation
 {
     /**
+     * @var QuerySerializerInterface
+     */
+    private $querySerializer;
+
+    /**
      * Set the name of the location
      *
-     * @param string $locationName
+     * @param string                        $locationName
+     * @param QuerySerializerInterface|null $querySerializer
      */
-    public function __construct($locationName = 'query')
+    public function __construct($locationName = 'query', QuerySerializerInterface $querySerializer = null)
     {
         parent::__construct($locationName);
+
+        $this->querySerializer = $querySerializer ?: new Rfc3986Serializer();
     }
 
     /**
@@ -42,7 +52,7 @@ class QueryLocation extends AbstractLocation
             $param
         );
 
-        $uri = $uri->withQuery(http_build_query($query, null, '&', PHP_QUERY_RFC3986));
+        $uri = $uri->withQuery($this->querySerializer->aggregate($query));
 
         return $request->withUri($uri);
     }
@@ -71,7 +81,7 @@ class QueryLocation extends AbstractLocation
                         $additional
                     );
 
-                    $uri = $uri->withQuery(http_build_query($query, null, '&', PHP_QUERY_RFC3986));
+                    $uri = $uri->withQuery($this->querySerializer->aggregate($query));
                     $request = $request->withUri($uri);
                 }
             }

--- a/tests/QuerySerializer/Rfc3986SerializerTest.php
+++ b/tests/QuerySerializer/Rfc3986SerializerTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace GuzzleHttp\Tests\Command\Guzzle\QuerySerializer;
+
+use GuzzleHttp\Command\Guzzle\QuerySerializer\Rfc3986Serializer;
+
+class Rfc3986SerializerTest extends \PHPUnit_Framework_TestCase
+{
+    public function queryProvider()
+    {
+        return [
+            [['foo' => 'bar'], 'foo=bar'],
+            [['foo' => [1, 2]], 'foo[0]=1&foo[1]=2'],
+            [['foo' => ['bar' => 'baz', 'bim' => [4, 5]]], 'foo[bar]=baz&foo[bim][0]=4&foo[bim][1]=5']
+        ];
+    }
+
+    /**
+     * @dataProvider queryProvider
+     */
+    public function testSerializeQueryParams(array $params, $expectedResult)
+    {
+        $serializer = new Rfc3986Serializer();
+        $result     = $serializer->aggregate($params);
+
+        $this->assertEquals($expectedResult, urldecode($result));
+    }
+
+    public function testCanRemoveNumericIndices()
+    {
+        $serializer = new Rfc3986Serializer(true);
+        $result     = $serializer->aggregate(['foo' => ['bar', 'baz'], 'bar' => ['bim' => [4, 5]]]);
+
+        $this->assertEquals('foo[]=bar&foo[]=baz&bar[bim][]=4&bar[bim][]=5', urldecode($result));
+    }
+}

--- a/tests/RequestLocation/QueryLocationTest.php
+++ b/tests/RequestLocation/QueryLocationTest.php
@@ -24,18 +24,17 @@ class QueryLocationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider queryProvider
      * @group RequestLocation
      */
-    public function testVisitsLocation(array $params, $expected)
+    public function testVisitsLocation()
     {
         $location = new QueryLocation();
-        $command = new Command('foo', $params);
+        $command = new Command('foo', ['foo' => 'bar']);
         $request = new Request('POST', 'http://httbin.org');
         $param = new Parameter(['name' => 'foo']);
         $request = $location->visit($command, $request, $param);
 
-        $this->assertEquals($expected, urldecode($request->getUri()->getQuery()));
+        $this->assertEquals('foo=bar', urldecode($request->getUri()->getQuery()));
     }
 
     public function testVisitsMultipleLocations()


### PR DESCRIPTION
This PR adds more flexibility to the way query params are serialized and does not introduce any breaking change.

This also open the road to more query serialization logic in the future (like what Guzzle 3 used to have). In my case i needed this as the API I integrated did not support numeric indices in the query string.