### PR TITLE
Exposing properties to a parent class

### DIFF
--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\ResponseInterface;
 class JsonLocation extends AbstractLocation
 {
     /** @var array The JSON document being visited */
-    private $json = [];
+    protected $json = [];
 
     /**
      * Set the name of the location

--- a/src/ResponseLocation/XmlLocation.php
+++ b/src/ResponseLocation/XmlLocation.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\ResponseInterface;
 class XmlLocation extends AbstractLocation
 {
     /** @var \SimpleXMLElement XML document being visited */
-    private $xml;
+    protected $xml;
 
     /**
      * Set the name of the location


### PR DESCRIPTION
It was impossible to modify json or xml properties for the parent class which made extension of JsonLocation and XmlLocation classes almost impossible.