### PR TITLE
Honor 'sentAs' name when property type is 'array'

### DIFF
--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -102,7 +102,7 @@ class JsonLocation extends AbstractLocation
             // Treat as javascript array
             if ($name) {
                 // name provided, store it under a key in the array
-                $subArray = isset($this->json[$name]) ? $this->json[$name] : null;
+                $subArray = isset($this->json[$key]) ? $this->json[$key] : null;
                 $result[$name] = $this->recurse($param, $subArray);
             } else {
                 // top-level `array` or an empty name


### PR DESCRIPTION
It appears that when using the following model, "sentAs" is not used when the type is set to 'array':

```json
"models" : {
        "Contact" : {
            "type":  "object",
            "properties" : {
                "id" : {
                    "type": "string",
                    "location" : "json",
                    "sentAs" : "_id"
                }
            },
            "additionalProperties" : "false"
        },
        "ContactsCollection" : {
            "type":  "object",
            "properties" : {
                "total" : {
                    "type": "integer",
                    "location" : "json"
                },
                "contacts" : {
                    "location" : "json",
                    "type" : "array",
                    "sentAs" : "data",
                    "items" : {
                        "$ref" : "Contact"
                    }
                }
            }
```