### PR TITLE
response_locations Config spread to Deserializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "guzzlehttp/guzzle-services",
+    "name": "pierozi/guzzle-services",
     "description": "Provides an implementation of the Guzzle Command library that uses Guzzle service descriptions to describe web services, serialize requests, and parse responses into easy to use model structures.",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pierozi/guzzle-services",
+    "name": "guzzlehttp/guzzle-services",
     "description": "Provides an implementation of the Guzzle Command library that uses Guzzle service descriptions to describe web services, serialize requests, and parse responses into easy to use model structures.",
     "license": "MIT",
     "authors": [

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -113,10 +113,13 @@ class GuzzleClient extends ServiceClient
     private function getDeserializer($responseToResultTransformer)
     {
         $process = (! isset($this->config['process']) || $this->config['process'] === true);
+        $locations = isset($this->config['response_locations']) && is_array($this->config['response_locations']) ?
+            $this->config['response_locations'] : []
+        ;
 
         return $responseToResultTransformer !== null
             ? $responseToResultTransformer
-            : new Deserializer($this->description, $process);
+            : new Deserializer($this->description, $process, $locations);
     }
 
     /**

--- a/tests/Fixture/ResponseLocation/CustomResponseLocation.php
+++ b/tests/Fixture/ResponseLocation/CustomResponseLocation.php
@@ -1,0 +1,46 @@
+<?php
+namespace GuzzleHttp\Tests\Command\Guzzle\Fixture\ResponseLocation;
+
+use GuzzleHttp\Command\Guzzle\Parameter;
+use GuzzleHttp\Command\Guzzle\ResponseLocation\JsonLocation;
+use GuzzleHttp\Command\ResultInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class CustomResponseLocationFoo
+ *
+ * @package GuzzleHttp\Tests\Command\Guzzle\Fixture\ResponseLocation
+ */
+class CustomResponseLocationFoo
+{
+    public $foo;
+    public $baz;
+
+    public function hydrate(array $attributes)
+    {
+        foreach ($attributes as $key => $value) {
+            $this->$key = $value;
+        }
+    }
+}
+
+/**
+ * Class CustomResponseLocation
+ *
+ * @package GuzzleHttp\Tests\Command\Guzzle\Fixture\ResponseLocation
+ */
+class CustomResponseLocation extends JsonLocation
+{
+    public function after(
+        ResultInterface $result,
+        ResponseInterface $response,
+        Parameter $model
+    ) {
+        $result = parent::after($result, $response, $model);
+
+        $entity = new CustomResponseLocationFoo;
+        $entity->hydrate($result->toArray());
+
+        return $entity;
+    }
+}


### PR DESCRIPTION
Hello,

I've been stuck a while before understanding the custom locations was not declared into `Deserializer` it seems the config was not parsed.

Config key named `response_locations` as the `GuzzleHttp\Command\Guzzle\GuzzleClient` constructor comment expect
> * response_locations: Associative array of location types mapping to
> * ResponseLocationInterface objects.