### PR TITLE
Use wire name when visiting array

### DIFF
--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -102,7 +102,7 @@ class JsonLocation extends AbstractLocation
             // Treat as javascript array
             if ($name) {
                 // name provided, store it under a key in the array
-                $subArray = isset($this->json[$name]) ? $this->json[$name] : null;
+                $subArray = isset($this->json[$key]) ? $this->json[$key] : null;
                 $result[$name] = $this->recurse($param, $subArray);
             } else {
                 // top-level `array` or an empty name


### PR DESCRIPTION
If the wire name isn't set then the name is used instead.
See https://github.com/guzzle/guzzle-services/blob/0a8b5d304305a36b7a907c8ccf4971f232c54832/src/Parameter.php#L327