### PR TITLE
Removed useless code - setting config defaults

### DIFF
--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -148,11 +148,6 @@ class GuzzleClient extends ServiceClient
      */
     protected function processConfig(array $config)
     {
-        // set defaults as an array if not provided
-        if (!isset($config['defaults'])) {
-            $config['defaults'] = [];
-        }
-
         // Add the handlers based on the configuration option
         $stack = $this->getHandlerStack();
 


### PR DESCRIPTION
This code is useless because:
1. `['defaults']` are never saved into a `$this->config` variable after this.
2. `getConfig()` will return an empty array anyway if config key isn't set. Therefore we don't need to fix №1 by saving new `$config` into `$this->config`