### PR TITLE
Bugfix - objects converted to array are not validated

### DIFF
--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -139,6 +139,7 @@ class SchemaValidator
             // Convert the value to an array
             if (!$valueIsArray && $value instanceof ToArrayInterface) {
                 $value = $value->toArray();
+                $valueIsArray = true;
             }
 
             if ($valueIsArray) {

--- a/tests/SchemaValidatorTest.php
+++ b/tests/SchemaValidatorTest.php
@@ -95,9 +95,11 @@ class SchemaValidatorTest extends \PHPUnit_Framework_TestCase
             'type'       => 'object',
             'properties' => [
                 'foo' => ['required' => 'true'],
+                'baz' => ['required' => 'true'],
             ],
         ]);
-        $this->assertTrue($this->validator->validate($p, $o));
+        $this->assertFalse($this->validator->validate($p, $o));
+        $this->assertEquals(['[test][baz] is required'], $this->validator->getErrors());
     }
 
     public function testMergesValidationErrorsInPropertiesWithParent()


### PR DESCRIPTION
`$valueIsArray` wasn't set to true after converting object to array, therefore further validation wasn't done.

It can easily be reproduced with SchemaValidatorTest::testConvertsObjectsToArraysWhenToArrayInterface().
Adding a required property
```                'baz' => ['required' => 'true'],```
without adding it into a mocked payload will not produce a validation error without this fix.