### PR TITLE
Default 'httpMethod' to 'GET' to Ensure PSR-7 1.6.x Compatibility

### DIFF
--- a/src/Operation.php
+++ b/src/Operation.php
@@ -53,7 +53,7 @@ class Operation implements ToArrayInterface
     {
         static $defaults = [
             'name' => '',
-            'httpMethod' => '',
+            'httpMethod' => 'GET',
             'uri' => '',
             'responseModel' => null,
             'notes' => '',
@@ -70,6 +70,10 @@ class Operation implements ToArrayInterface
 
         if (isset($config['extends'])) {
             $config = $this->resolveExtends($config['extends'], $config);
+        }
+
+        if (array_key_exists('httpMethod', $config) && empty($config['httpMethod'])) {
+          throw new \InvalidArgumentException('httpMethod must be a non-empty string');
         }
 
         $this->config = $config + $defaults;

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -122,6 +122,27 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => 'baz', 'bar' => 123], $o->getData());
     }
 
+    public function testDefaultsHttpMethodToGET()
+    {
+        $o = new Operation();
+        $this->assertEquals('GET', $o->getHttpMethod());
+    }
+
+    public function testCanProvideAlternateHttpMethod()
+    {
+        $o = new Operation(['httpMethod' => 'POST']);
+        $this->assertEquals('POST', $o->getHttpMethod());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMesssage httpMethod must be a non-empty string
+     */
+    public function testEnsuresHttpMethodIsNotEmptyString()
+    {
+        new Operation(['httpMethod' => '']);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMesssage Parameters must be arrays
@@ -196,6 +217,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
                     'summary' => 'foo'
                 ],
                 'B' => [
+                    'httpMethod' => 'POST',
                     'extends' => 'A',
                     'summary' => 'Bar'
                 ],
@@ -210,17 +232,20 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $a = $d->getOperation('A');
+        $this->assertEquals('GET', $a->getHttpMethod());
         $this->assertEquals('foo', $a->getSummary());
         $this->assertTrue($a->hasParam('A'));
         $this->assertEquals('string', $a->getParam('B')->getType());
 
         $b = $d->getOperation('B');
         $this->assertTrue($a->hasParam('A'));
+        $this->assertEquals('POST', $b->getHttpMethod());
         $this->assertEquals('Bar', $b->getSummary());
         $this->assertEquals('string', $a->getParam('B')->getType());
 
         $c = $d->getOperation('C');
         $this->assertTrue($a->hasParam('A'));
+        $this->assertEquals('POST', $c->getHttpMethod());
         $this->assertEquals('Bar', $c->getSummary());
         $this->assertEquals('number', $c->getParam('B')->getType());
     }


### PR DESCRIPTION
PSR-7 requires a method to be set on Request objects at the time they are created, but the Operation object previously defaulted the method to an empty string. Now we default it to 'GET', which should be a safe choice.

In addition, if a request is mis-configured to force the request method to an empty string, there is now a validation for that.

Closes #166.

_(If this should be based off of the `develop` branch, per #170, let me know and I will rebase it)_.