### PR TITLE
[2.0] Add Support for Polymorphic Response Field Types

### DIFF
--- a/src/Operation.php
+++ b/src/Operation.php
@@ -53,7 +53,7 @@ class Operation implements ToArrayInterface
     {
         static $defaults = [
             'name' => '',
-            'httpMethod' => '',
+            'httpMethod' => 'GET',
             'uri' => '',
             'responseModel' => null,
             'notes' => '',
@@ -70,6 +70,10 @@ class Operation implements ToArrayInterface
 
         if (isset($config['extends'])) {
             $config = $this->resolveExtends($config['extends'], $config);
+        }
+
+        if (array_key_exists('httpMethod', $config) && empty($config['httpMethod'])) {
+          throw new \InvalidArgumentException('httpMethod must be a non-empty string');
         }
 
         $this->config = $config + $defaults;

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -232,7 +232,7 @@ class SchemaValidator
         // Validate that the type is correct. If the type is string but an
         // integer was passed, the class can be instructed to cast the integer
         // to a string to pass validation. This is the default behavior.
-        if ($type && (!$type = $this->determineType($type, $value))) {
+        if ($type && (!$type = $param->determineType($value))) {
             if ($this->castIntegerToStringType
                 && $param->getType() == 'string'
                 && is_integer($value)

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -122,6 +122,27 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => 'baz', 'bar' => 123], $o->getData());
     }
 
+    public function testDefaultsHttpMethodToGET()
+    {
+        $o = new Operation();
+        $this->assertEquals('GET', $o->getHttpMethod());
+    }
+
+    public function testCanProvideAlternateHttpMethod()
+    {
+        $o = new Operation(['httpMethod' => 'POST']);
+        $this->assertEquals('POST', $o->getHttpMethod());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMesssage httpMethod must be a non-empty string
+     */
+    public function testEnsuresHttpMethodIsNotEmptyString()
+    {
+        new Operation(['httpMethod' => '']);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMesssage Parameters must be arrays
@@ -196,6 +217,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
                     'summary' => 'foo'
                 ],
                 'B' => [
+                    'httpMethod' => 'POST',
                     'extends' => 'A',
                     'summary' => 'Bar'
                 ],
@@ -210,17 +232,20 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $a = $d->getOperation('A');
+        $this->assertEquals('GET', $a->getHttpMethod());
         $this->assertEquals('foo', $a->getSummary());
         $this->assertTrue($a->hasParam('A'));
         $this->assertEquals('string', $a->getParam('B')->getType());
 
         $b = $d->getOperation('B');
         $this->assertTrue($a->hasParam('A'));
+        $this->assertEquals('POST', $b->getHttpMethod());
         $this->assertEquals('Bar', $b->getSummary());
         $this->assertEquals('string', $a->getParam('B')->getType());
 
         $c = $d->getOperation('C');
         $this->assertTrue($a->hasParam('A'));
+        $this->assertEquals('POST', $c->getHttpMethod());
         $this->assertEquals('Bar', $c->getSummary());
         $this->assertEquals('number', $c->getParam('B')->getType());
     }


### PR DESCRIPTION
This allows fields within a response model to vary within a set of allowed types instead of being required to be a specific JSON schema value type.

This also corrects detection of null response values. It also fixes detection of associative vs. indexed arrays so that the order in which the type definitions appear in the service description doesn't affect which type gets returned when a field can be either an object or an array.

Depends on #167 (to fix the test suite), and closes #165.

_(If this should be based off of the `develop` branch, per #170, let me know and I will rebase it)_.