### PR TITLE
WIP: Support Filters Being Bound to Different Stages of Processing

### DIFF
--- a/src/Operation.php
+++ b/src/Operation.php
@@ -53,7 +53,7 @@ class Operation implements ToArrayInterface
     {
         static $defaults = [
             'name' => '',
-            'httpMethod' => '',
+            'httpMethod' => 'GET',
             'uri' => '',
             'responseModel' => null,
             'notes' => '',
@@ -70,6 +70,10 @@ class Operation implements ToArrayInterface
 
         if (isset($config['extends'])) {
             $config = $this->resolveExtends($config['extends'], $config);
+        }
+
+        if (array_key_exists('httpMethod', $config) && empty($config['httpMethod'])) {
+          throw new \InvalidArgumentException('httpMethod must be a non-empty string');
         }
 
         $this->config = $config + $defaults;

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -256,7 +256,9 @@ class Parameter implements ToArrayInterface
         $this->required = (bool) $this->required;
         $this->data = (array) $this->data;
 
-        if ($this->filters) {
+        if (empty($this->filters)) {
+            $this->filters = [];
+        } else {
             $this->setFilters((array) $this->filters);
         }
 
@@ -320,7 +322,7 @@ class Parameter implements ToArrayInterface
         }
 
         // Formats are applied exclusively and supercede filters
-        if ($this->format) {
+        if (!empty($this->format)) {
             if (!$this->serviceDescription) {
                 throw new \RuntimeException('No service description was set so '
                     . 'the value cannot be formatted.');
@@ -334,7 +336,7 @@ class Parameter implements ToArrayInterface
         }
 
         // Apply filters to the value
-        if ($this->filters) {
+        if (!empty($this->filters)) {
             $value = $this->invokeCustomFilters($value, $stage);
         }
 
@@ -532,7 +534,7 @@ class Parameter implements ToArrayInterface
      */
     public function getFilters()
     {
-        return $this->filters ?: [];
+        return $this->filters;
     }
 
     /**
@@ -650,6 +652,7 @@ class Parameter implements ToArrayInterface
     private function setFilters(array $filters)
     {
         $this->filters = [];
+
         foreach ($filters as $filter) {
             $this->addFilter($filter);
         }
@@ -686,11 +689,7 @@ class Parameter implements ToArrayInterface
             }
         }
 
-        if (!$this->filters) {
-            $this->filters = [$filter];
-        } else {
-            $this->filters[] = $filter;
-        }
+        $this->filters[] = $filter;
 
         return $this;
     }
@@ -792,7 +791,7 @@ class Parameter implements ToArrayInterface
      *
      * @return array The array of arguments, with all placeholders replaced.
      */
-    function expandFilterArgs(array $filterArgs, $value, $stage) {
+    private function expandFilterArgs(array $filterArgs, $value, $stage) {
         $replacements = [
             '@value'  => $value,
             '@api'    => $this,

--- a/src/RequestLocation/AbstractLocation.php
+++ b/src/RequestLocation/AbstractLocation.php
@@ -62,7 +62,7 @@ abstract class AbstractLocation implements RequestLocationInterface
     {
         return is_array($value)
             ? $this->resolveRecursively($value, $param)
-            : $param->filter($value);
+            : $param->filter($value, Parameter::FILTER_STAGE_REQUEST_WIRE);
     }
 
     /**
@@ -96,6 +96,6 @@ abstract class AbstractLocation implements RequestLocationInterface
             }
         }
 
-        return $param->filter($value);
+        return $param->filter($value, Parameter::FILTER_STAGE_REQUEST_WIRE);
     }
 }

--- a/src/RequestLocation/BodyLocation.php
+++ b/src/RequestLocation/BodyLocation.php
@@ -35,15 +35,20 @@ class BodyLocation extends AbstractLocation
         RequestInterface $request,
         Parameter $param
     ) {
-        $oldValue = $request->getBody()->getContents();
+        $existingResponse = $request->getBody()->getContents();
 
         $value = $command[$param->getName()];
-        $value = $param->getName() . '=' . $param->filter($value);
+        $filteredValue =
+            $param->filter($value, Parameter::FILTER_STAGE_REQUEST_WIRE);
 
-        if ($oldValue !== '') {
-            $value = $oldValue . '&' . $value;
+        $valueForResponse = sprintf('%s=%s', $param->getName(), $filteredValue);
+
+        if ($existingResponse == '') {
+            $response = $valueForResponse;
+        } else {
+            $response = $existingResponse . '&' . $valueForResponse;
         }
 
-        return $request->withBody(Psr7\stream_for($value));
+        return $request->withBody(Psr7\stream_for($response));
     }
 }

--- a/src/RequestLocation/HeaderLocation.php
+++ b/src/RequestLocation/HeaderLocation.php
@@ -36,8 +36,10 @@ class HeaderLocation extends AbstractLocation
         Parameter $param
     ) {
         $value = $command[$param->getName()];
+        $filteredValue =
+            $param->filter($value, Parameter::FILTER_STAGE_REQUEST_WIRE);
 
-        return $request->withHeader($param->getWireName(), $param->filter($value));
+        return $request->withHeader($param->getWireName(), $filteredValue);
     }
 
     /**
@@ -57,7 +59,12 @@ class HeaderLocation extends AbstractLocation
         if ($additional && ($additional->getLocation() === $this->locationName)) {
             foreach ($command->toArray() as $key => $value) {
                 if (!$operation->hasParam($key)) {
-                    $request = $request->withHeader($key, $additional->filter($value));
+                    $filteredValue = $additional->filter(
+                        $value,
+                        Parameter::FILTER_STAGE_REQUEST_WIRE
+                    );
+
+                    $request = $request->withHeader($key, $filteredValue);
                 }
             }
         }

--- a/src/RequestLocation/XmlLocation.php
+++ b/src/RequestLocation/XmlLocation.php
@@ -154,7 +154,8 @@ class XmlLocation extends AbstractLocation
      */
     protected function addXml(\XMLWriter $writer, Parameter $param, $value)
     {
-        $value = $param->filter($value);
+        $filteredValue =
+            $param->filter($value, Parameter::FILTER_STAGE_REQUEST_WIRE);
         $type = $param->getType();
         $name = $param->getWireName();
         $prefix = null;
@@ -172,9 +173,9 @@ class XmlLocation extends AbstractLocation
                 }
             }
             if ($param->getType() == 'array') {
-                $this->addXmlArray($writer, $param, $value);
+                $this->addXmlArray($writer, $param, $filteredValue);
             } elseif ($param->getType() == 'object') {
-                $this->addXmlObject($writer, $param, $value);
+                $this->addXmlObject($writer, $param, $filteredValue);
             }
             if (!$param->getData('xmlFlattened')) {
                 $writer->endElement();
@@ -182,9 +183,21 @@ class XmlLocation extends AbstractLocation
             return;
         }
         if ($param->getData('xmlAttribute')) {
-            $this->writeAttribute($writer, $prefix, $name, $namespace, $value);
+            $this->writeAttribute(
+                $writer,
+                $prefix,
+                $name,
+                $namespace,
+                $filteredValue
+            );
         } else {
-            $this->writeElement($writer, $prefix, $name, $namespace, $value);
+            $this->writeElement(
+                $writer,
+                $prefix,
+                $name,
+                $namespace,
+                $filteredValue
+            );
         }
     }
 

--- a/src/ResponseLocation/BodyLocation.php
+++ b/src/ResponseLocation/BodyLocation.php
@@ -32,7 +32,11 @@ class BodyLocation extends AbstractLocation
         ResponseInterface $response,
         Parameter $param
     ) {
-        $result[$param->getName()] = $param->filter($response->getBody());
+        $value = $response->getBody();
+        $filteredValue =
+            $param->filter($value, Parameter::FILTER_STAGE_RESPONSE_WIRE);
+
+        $result[$param->getName()] = $filteredValue;
 
         return $result;
     }

--- a/src/ResponseLocation/HeaderLocation.php
+++ b/src/ResponseLocation/HeaderLocation.php
@@ -39,7 +39,11 @@ class HeaderLocation extends AbstractLocation
             if (is_array($header)) {
                 $header = array_shift($header);
             }
-            $result[$name] = $param->filter($header);
+
+            $filteredHeader =
+                $param->filter($header, Parameter::FILTER_STAGE_RESPONSE_WIRE);
+
+            $result[$name] = $filteredHeader;
         }
 
         return $result;

--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -128,7 +128,10 @@ class JsonLocation extends AbstractLocation
     private function recurse(Parameter $param, $value)
     {
         if (!is_array($value)) {
-            return $param->filter($value);
+            $filteredValue =
+                $param->filter($value, Parameter::FILTER_STAGE_RESPONSE_WIRE);
+
+            return $filteredValue;
         }
 
         $result = [];
@@ -171,6 +174,6 @@ class JsonLocation extends AbstractLocation
             }
         }
 
-        return $param->filter($result);
+        return $param->filter($result, Parameter::FILTER_STAGE_RESPONSE_WIRE);
     }
 }

--- a/src/ResponseLocation/ReasonPhraseLocation.php
+++ b/src/ResponseLocation/ReasonPhraseLocation.php
@@ -32,9 +32,11 @@ class ReasonPhraseLocation extends AbstractLocation
         ResponseInterface $response,
         Parameter $param
     ) {
-        $result[$param->getName()] = $param->filter(
-            $response->getReasonPhrase()
-        );
+        $value = $response->getReasonPhrase();
+        $filteredValue =
+            $param->filter($value, Parameter::FILTER_STAGE_RESPONSE_WIRE);
+
+        $result[$param->getName()] = $filteredValue;
 
         return $result;
     }

--- a/src/ResponseLocation/StatusCodeLocation.php
+++ b/src/ResponseLocation/StatusCodeLocation.php
@@ -32,7 +32,11 @@ class StatusCodeLocation extends AbstractLocation
         ResponseInterface $response,
         Parameter $param
     ) {
-        $result[$param->getName()] = $param->filter($response->getStatusCode());
+        $value = $response->getStatusCode();
+        $filteredValue =
+            $param->filter($value, Parameter::FILTER_STAGE_RESPONSE_WIRE);
+
+        $result[$param->getName()] = $filteredValue;
 
         return $result;
     }

--- a/src/ResponseLocation/XmlLocation.php
+++ b/src/ResponseLocation/XmlLocation.php
@@ -125,7 +125,8 @@ class XmlLocation extends AbstractLocation
 
         // Filter out the value
         if (isset($result)) {
-            $result = $param->filter($result);
+            $result =
+                $param->filter($result, Parameter::FILTER_STAGE_RESPONSE_WIRE);
         }
 
         return $result;

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -145,9 +145,15 @@ class Serializer
             /* @var Parameter $arg */
             if ($arg->getLocation() == 'uri') {
                 if (isset($command[$name])) {
-                    $variables[$name] = $arg->filter($command[$name]);
-                    if (!is_array($variables[$name])) {
-                        $variables[$name] = (string) $variables[$name];
+                    $filteredValue = $arg->filter(
+                        $command[$name],
+                        Parameter::FILTER_STAGE_REQUEST_WIRE
+                    );
+
+                    if (is_array($filteredValue)) {
+                        $variables[$name] = $filteredValue;
+                    } else {
+                        $variables[$name] = (string)$filteredValue;
                     }
                 }
             }

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -122,6 +122,27 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => 'baz', 'bar' => 123], $o->getData());
     }
 
+    public function testDefaultsHttpMethodToGET()
+    {
+        $o = new Operation();
+        $this->assertEquals('GET', $o->getHttpMethod());
+    }
+
+    public function testCanProvideAlternateHttpMethod()
+    {
+        $o = new Operation(['httpMethod' => 'POST']);
+        $this->assertEquals('POST', $o->getHttpMethod());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMesssage httpMethod must be a non-empty string
+     */
+    public function testEnsuresHttpMethodIsNotEmptyString()
+    {
+        new Operation(['httpMethod' => '']);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMesssage Parameters must be arrays
@@ -196,6 +217,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
                     'summary' => 'foo'
                 ],
                 'B' => [
+                    'httpMethod' => 'POST',
                     'extends' => 'A',
                     'summary' => 'Bar'
                 ],
@@ -210,17 +232,20 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $a = $d->getOperation('A');
+        $this->assertEquals('GET', $a->getHttpMethod());
         $this->assertEquals('foo', $a->getSummary());
         $this->assertTrue($a->hasParam('A'));
         $this->assertEquals('string', $a->getParam('B')->getType());
 
         $b = $d->getOperation('B');
         $this->assertTrue($a->hasParam('A'));
+        $this->assertEquals('POST', $b->getHttpMethod());
         $this->assertEquals('Bar', $b->getSummary());
         $this->assertEquals('string', $a->getParam('B')->getType());
 
         $c = $d->getOperation('C');
         $this->assertTrue($a->hasParam('A'));
+        $this->assertEquals('POST', $c->getHttpMethod());
         $this->assertEquals('Bar', $c->getSummary());
         $this->assertEquals('number', $c->getParam('B')->getType());
     }


### PR DESCRIPTION
Makes it possible for a filter definition to include a new `stage` key that can be set to `before_validation`, `after_validation`, `request_wire`, or `response_wire`; which binds the filter to fire off either before validation (the default), after validation, before being written to the wire in a request, or after being read from the wire from a response, respectively.

Still needs tests.

Depends on #167, closes #169, and closes #134.