### PR TITLE
Update to Guzzle 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,14 @@ language: php
 dist: trusty
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
+  - 7.2.5
+  - 7.3
+  - 7.4
   - nightly
 
 matrix:
   fast_finish: true
   allow_failures:
-    - php: 7.1
     - php: nightly
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
 sudo: false
 language: php
 
+dist: trusty
+
 php:
+  - 5.5
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
   - nightly
 
 matrix:
   fast_finish: true
   allow_failures:
     - php: 7.1
-    - php: hhvm
     - php: nightly
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,9 @@
     ],
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "^6.2",
-        "guzzlehttp/command": "~1.0"
+        "guzzlehttp/guzzle": "^6.2|^7.0.1",
+        "guzzlehttp/command": "~1.0",
+        "guzzlehttp/uri-template": "^0.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "guzzlehttp/uri-template": "^0.2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
-        "guzzlehttp/guzzle": "^6.2|^7.0.1",
+        "php": ">=7.2.5",
+        "guzzlehttp/guzzle": "^7.0.1",
         "guzzlehttp/command": "~1.0",
         "guzzlehttp/uri-template": "^0.2.0"
     },

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Command\Guzzle\RequestLocation\XmlLocation;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\UriResolver;
+use GuzzleHttp\UriTemplate\UriTemplate;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -155,7 +156,7 @@ class Serializer
         }
 
         // Expand the URI template.
-        $uri = \GuzzleHttp\uri_template($operation->getUri(), $variables);
+        $uri = UriTemplate::expand($operation->getUri(), $variables);
 
         return new Request(
             $operation->getHttpMethod(),

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Command\Guzzle\RequestLocation\RequestLocationInterface;
 use GuzzleHttp\Command\Guzzle\RequestLocation\XmlLocation;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\UriResolver;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -158,7 +159,7 @@ class Serializer
 
         return new Request(
             $operation->getHttpMethod(),
-            Uri::resolve($this->description->getBaseUri(), $uri)
+            UriResolver::resolve($this->description->getBaseUri(), new Uri($uri))
         );
     }
 }

--- a/tests/DescriptionTest.php
+++ b/tests/DescriptionTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
@@ -9,7 +10,7 @@ use GuzzleHttp\Command\Guzzle\SchemaFormatter;
 /**
  * @covers \GuzzleHttp\Command\Guzzle\Description
  */
-class DescriptionTest extends \PHPUnit_Framework_TestCase
+class DescriptionTest extends TestCase
 {
     protected $operations;
 

--- a/tests/DeserializerTest.php
+++ b/tests/DeserializerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\Guzzle\Description;
@@ -18,7 +19,7 @@ use Predis\Response\ResponseInterface;
 /**
  * @covers \GuzzleHttp\Command\Guzzle\Deserializer
  */
-class DeserializerTest extends \PHPUnit_Framework_TestCase
+class DeserializerTest extends TestCase
 {
     /** @var ServiceClientInterface|\PHPUnit_Framework_MockObject_MockObject */
     private $serviceClient;

--- a/tests/GuzzleClientTest.php
+++ b/tests/GuzzleClientTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\Guzzle\Description;
@@ -16,7 +17,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * @covers \GuzzleHttp\Command\Guzzle\GuzzleClient
  */
-class GuzzleClientTest extends \PHPUnit_Framework_TestCase
+class GuzzleClientTest extends TestCase
 {
     public function testExecuteCommandViaMagicMethod()
     {

--- a/tests/Handler/ValidatedDescriptionHandlerTest.php
+++ b/tests/Handler/ValidatedDescriptionHandlerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\Handler;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
@@ -8,7 +9,7 @@ use GuzzleHttp\Command\Guzzle\GuzzleClient;
 /**
  * @covers \GuzzleHttp\Command\Guzzle\Handler\ValidatedDescriptionHandler
  */
-class ValidatedDescriptionHandlerTest extends \PHPUnit_Framework_TestCase
+class ValidatedDescriptionHandlerTest extends TestCase
 {
 
     /**

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -1,13 +1,14 @@
 <?php
 namespace Guzzle\Tests\Service\Description;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\Operation;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\Operation
  */
-class OperationTest extends \PHPUnit_Framework_TestCase
+class OperationTest extends TestCase
 {
     public static function strtoupper($string)
     {

--- a/tests/ParameterTest.php
+++ b/tests/ParameterTest.php
@@ -1,13 +1,14 @@
 <?php
 namespace Guzzle\Tests\Service\Description;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\Parameter;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\Parameter
  */
-class ParameterTest extends \PHPUnit_Framework_TestCase
+class ParameterTest extends TestCase
 {
     protected $data = [
         'name'            => 'foo',

--- a/tests/QuerySerializer/Rfc3986SerializerTest.php
+++ b/tests/QuerySerializer/Rfc3986SerializerTest.php
@@ -1,9 +1,10 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\QuerySerializer;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Guzzle\QuerySerializer\Rfc3986Serializer;
 
-class Rfc3986SerializerTest extends \PHPUnit_Framework_TestCase
+class Rfc3986SerializerTest extends TestCase
 {
     public function queryProvider()
     {

--- a/tests/RequestLocation/BodyLocationTest.php
+++ b/tests/RequestLocation/BodyLocationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\RequestLocation;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\RequestLocation\BodyLocation;
@@ -9,7 +10,7 @@ use GuzzleHttp\Psr7\Request;
 /**
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\BodyLocation
  */
-class BodyLocationTest extends \PHPUnit_Framework_TestCase
+class BodyLocationTest extends TestCase
 {
     /**
      * @group RequestLocation

--- a/tests/RequestLocation/FormParamLocationTest.php
+++ b/tests/RequestLocation/FormParamLocationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\RequestLocation;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
@@ -12,7 +13,7 @@ use GuzzleHttp\Psr7\Request;
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\FormParamLocation
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\AbstractLocation
  */
-class FormParamLocationTest extends \PHPUnit_Framework_TestCase
+class FormParamLocationTest extends TestCase
 {
     /**
      * @group RequestLocation

--- a/tests/RequestLocation/HeaderLocationTest.php
+++ b/tests/RequestLocation/HeaderLocationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\RequestLocation;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
@@ -11,7 +12,7 @@ use GuzzleHttp\Psr7\Request;
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\HeaderLocation
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\AbstractLocation
  */
-class HeaderLocationTest extends \PHPUnit_Framework_TestCase
+class HeaderLocationTest extends TestCase
 {
     /**
      * @group RequestLocation

--- a/tests/RequestLocation/JsonLocationTest.php
+++ b/tests/RequestLocation/JsonLocationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\RequestLocation;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
@@ -11,7 +12,7 @@ use GuzzleHttp\Psr7\Request;
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\JsonLocation
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\AbstractLocation
  */
-class JsonLocationTest extends \PHPUnit_Framework_TestCase
+class JsonLocationTest extends TestCase
 {
     /**
      * @group RequestLocation

--- a/tests/RequestLocation/MultiPartLocationTest.php
+++ b/tests/RequestLocation/MultiPartLocationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\RequestLocation;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
@@ -11,7 +12,7 @@ use GuzzleHttp\Psr7\Request;
 /**
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\MultiPartLocation
  */
-class MultiPartLocationTest extends \PHPUnit_Framework_TestCase
+class MultiPartLocationTest extends TestCase
 {
     /**
      * @group RequestLocation

--- a/tests/RequestLocation/QueryLocationTest.php
+++ b/tests/RequestLocation/QueryLocationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\RequestLocation;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
@@ -12,7 +13,7 @@ use GuzzleHttp\Psr7\Request;
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\QueryLocation
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\AbstractLocation
  */
-class QueryLocationTest extends \PHPUnit_Framework_TestCase
+class QueryLocationTest extends TestCase
 {
     public function queryProvider()
     {

--- a/tests/RequestLocation/XmlLocationTest.php
+++ b/tests/RequestLocation/XmlLocationTest.php
@@ -492,6 +492,7 @@ class XmlLocationTest extends \PHPUnit_Framework_TestCase
         $stack = new HandlerStack($mock);
         $stack->push($history);
         $operation['uri'] = 'http://httpbin.org';
+        $operation['httpMethod'] = 'GET';
         $client = new GuzzleClient(
             new Client(['handler' => $stack]),
             new Description([

--- a/tests/RequestLocation/XmlLocationTest.php
+++ b/tests/RequestLocation/XmlLocationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\RequestLocation;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Client;
 use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\Description;
@@ -17,7 +18,7 @@ use GuzzleHttp\Psr7\Response;
 /**
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\XmlLocation
  */
-class XmlLocationTest extends \PHPUnit_Framework_TestCase
+class XmlLocationTest extends TestCase
 {
     /**
      * @group RequestLocation

--- a/tests/ResponseLocation/BodyLocationTest.php
+++ b/tests/ResponseLocation/BodyLocationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\ResponseLocation;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\ResponseLocation\BodyLocation;
 use GuzzleHttp\Command\Result;
@@ -10,7 +11,7 @@ use GuzzleHttp\Psr7\Response;
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\BodyLocation
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\AbstractLocation
  */
-class BodyLocationTest extends \PHPUnit_Framework_TestCase
+class BodyLocationTest extends TestCase
 {
     /**
      * @group ResponseLocation

--- a/tests/ResponseLocation/HeaderLocationTest.php
+++ b/tests/ResponseLocation/HeaderLocationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\ResponseLocation;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\ResponseLocation\HeaderLocation;
 use GuzzleHttp\Command\Result;
@@ -10,7 +11,7 @@ use GuzzleHttp\Psr7\Response;
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\HeaderLocation
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\AbstractLocation
  */
-class HeaderLocationTest extends \PHPUnit_Framework_TestCase
+class HeaderLocationTest extends TestCase
 {
     /**
      * @group ResponseLocation

--- a/tests/ResponseLocation/JsonLocationTest.php
+++ b/tests/ResponseLocation/JsonLocationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\ResponseLocation;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Client;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
@@ -15,7 +16,7 @@ use GuzzleHttp\Psr7\Response;
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\JsonLocation
  * @covers \GuzzleHttp\Command\Guzzle\Deserializer
  */
-class JsonLocationTest extends \PHPUnit_Framework_TestCase
+class JsonLocationTest extends TestCase
 {
 
     /**

--- a/tests/ResponseLocation/ReasonPhraseLocationTest.php
+++ b/tests/ResponseLocation/ReasonPhraseLocationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\ResponseLocation;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\ResponseLocation\ReasonPhraseLocation;
 use GuzzleHttp\Command\Result;
@@ -10,7 +11,7 @@ use GuzzleHttp\Psr7\Response;
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\ReasonPhraseLocation
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\AbstractLocation
  */
-class ReasonPhraseLocationTest extends \PHPUnit_Framework_TestCase
+class ReasonPhraseLocationTest extends TestCase
 {
     /**
      * @group ResponseLocation

--- a/tests/ResponseLocation/StatusCodeLocationTest.php
+++ b/tests/ResponseLocation/StatusCodeLocationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\ResponseLocation;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\ResponseLocation\StatusCodeLocation;
 use GuzzleHttp\Command\Result;
@@ -10,7 +11,7 @@ use GuzzleHttp\Psr7\Response;
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\StatusCodeLocation
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\AbstractLocation
  */
-class StatusCodeLocationTest extends \PHPUnit_Framework_TestCase
+class StatusCodeLocationTest extends TestCase
 {
     /**
      * @group ResponseLocation

--- a/tests/ResponseLocation/XmlLocationTest.php
+++ b/tests/ResponseLocation/XmlLocationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle\ResponseLocation;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\ResponseLocation\XmlLocation;
 use GuzzleHttp\Command\Result;
@@ -9,7 +10,7 @@ use GuzzleHttp\Psr7\Response;
 /**
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\XmlLocation
  */
-class XmlLocationTest extends \PHPUnit_Framework_TestCase
+class XmlLocationTest extends TestCase
 {
     /**
      * @group ResponseLocation

--- a/tests/SchemaFormatterTest.php
+++ b/tests/SchemaFormatterTest.php
@@ -1,12 +1,13 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Guzzle\SchemaFormatter;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\SchemaFormatter
  */
-class SchemaFormatterTest extends \PHPUnit_Framework_TestCase
+class SchemaFormatterTest extends TestCase
 {
     public function dateTimeProvider()
     {

--- a/tests/SchemaValidatorTest.php
+++ b/tests/SchemaValidatorTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Guzzle\Tests\Service\Description;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\SchemaValidator;
 use GuzzleHttp\Command\ToArrayInterface;
@@ -8,7 +9,7 @@ use GuzzleHttp\Command\ToArrayInterface;
 /**
  * @covers \GuzzleHttp\Command\Guzzle\SchemaValidator
  */
-class SchemaValidatorTest extends \PHPUnit_Framework_TestCase
+class SchemaValidatorTest extends TestCase
 {
     /** @var SchemaValidator */
     protected $validator;

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\Serializer;
@@ -9,7 +10,7 @@ use GuzzleHttp\Psr7\Request;
 /**
  * @covers \GuzzleHttp\Command\Guzzle\Serializer
  */
-class SerializerTest extends \PHPUnit_Framework_TestCase
+class SerializerTest extends TestCase
 {
     public function testAllowsUriTemplates()
     {


### PR DESCRIPTION
As the title says. This will require https://github.com/guzzle/command/pull/40

- Remove deprecated function Uri::resolve
- Fix tests
- Update for Guzzle 7