### PR TITLE
Guzzle 7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,14 @@ sudo: false
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
+  - 7.3
+  - 7.4
   - hhvm
   - nightly
 
 matrix:
   fast_finish: true
   allow_failures:
-    - php: 7.1
     - php: hhvm
     - php: nightly
 

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
-        "guzzlehttp/guzzle": "^7.0",
+        "php": ">=7.3",
+        "guzzlehttp/guzzle": "^7.0.1",
         "guzzlehttp/command": "dev-master",
         "guzzlehttp/uri-template": "^0.2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,13 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
-        "guzzlehttp/guzzle": "^6.2",
-        "guzzlehttp/command": "~1.0"
+        "php": ">=7.1",
+        "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/command": "dev-master",
+        "guzzlehttp/uri-template": "^0.2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~9.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,13 +2,13 @@
 <phpunit bootstrap="./vendor/autoload.php"
          colors="true">
     <testsuites>
-        <testsuite>
+        <testsuite name="Unit">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./app</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/Handler/ValidatedDescriptionHandler.php
+++ b/src/Handler/ValidatedDescriptionHandler.php
@@ -49,6 +49,10 @@ class ValidatedDescriptionHandler
 
                 if (! $this->validator->validate($schema, $value)) {
                     $errors = array_merge($errors, $this->validator->getErrors());
+                } elseif ($value !== $command[$name]) {
+                    // Update the config value if it changed and no validation
+                    // errors were encountered
+                    $command[$name] = $value;
                 }
             }
 
@@ -60,6 +64,8 @@ class ValidatedDescriptionHandler
                         $params->setName($name);
                         if (! $this->validator->validate($params, $value)) {
                             $errors = array_merge($errors, $this->validator->getErrors());
+                        } elseif ($value !== $command[$name]) {
+                            $command[$name] = $value;
                         }
                     }
                 }

--- a/src/Handler/ValidatedDescriptionHandler.php
+++ b/src/Handler/ValidatedDescriptionHandler.php
@@ -50,8 +50,9 @@ class ValidatedDescriptionHandler
                 if (! $this->validator->validate($schema, $value)) {
                     $errors = array_merge($errors, $this->validator->getErrors());
                 } elseif ($value !== $command[$name]) {
-                    // Update the config value if it changed and no validation
-                    // errors were encountered
+                    // Update the config value if it changed and no validation errors were encountered.
+                    // This happen when the user extending an operation
+                    // See https://github.com/guzzle/guzzle-services/issues/145
                     $command[$name] = $value;
                 }
             }

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -12,6 +12,8 @@ use GuzzleHttp\Command\Guzzle\RequestLocation\RequestLocationInterface;
 use GuzzleHttp\Command\Guzzle\RequestLocation\XmlLocation;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\UriResolver;
+use GuzzleHttp\UriTemplate\UriTemplate;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -154,11 +156,11 @@ class Serializer
         }
 
         // Expand the URI template.
-        $uri = \GuzzleHttp\uri_template($operation->getUri(), $variables);
+        $uri = new Uri(UriTemplate::expand($operation->getUri(), $variables));
 
         return new Request(
-            $operation->getHttpMethod(),
-            Uri::resolve($this->description->getBaseUri(), $uri)
+            $operation->getHttpMethod() ?: 'GET',
+            UriResolver::resolve($this->description->getBaseUri(), $uri)
         );
     }
 }

--- a/tests/DescriptionTest.php
+++ b/tests/DescriptionTest.php
@@ -5,15 +5,17 @@ use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\SchemaFormatter;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\Description
  */
-class DescriptionTest extends \PHPUnit_Framework_TestCase
+class DescriptionTest extends TestCase
 {
     protected $operations;
 
-    public function setup()
+    public function setup(): void
     {
         $this->operations = [
             'test_command' => [
@@ -65,11 +67,9 @@ class DescriptionTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($op->getResponseModel());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRetrievingMissingModelThrowsException()
     {
+        $this->expectException(InvalidArgumentException::class);
         $d = new Description([]);
         $d->getModel('foo');
     }
@@ -105,20 +105,16 @@ class DescriptionTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($d->getData('missing'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testThrowsExceptionForMissingOperation()
     {
+        $this->expectException(InvalidArgumentException::class);
         $s = new Description([]);
         $this->assertNull($s->getOperation('foo'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testValidatesOperationTypes()
     {
+        $this->expectException(InvalidArgumentException::class);
         new Description([
             'operations' => ['foo' => new \stdClass()]
         ]);

--- a/tests/DeserializerTest.php
+++ b/tests/DeserializerTest.php
@@ -3,6 +3,7 @@ namespace GuzzleHttp\Tests\Command\Guzzle;
 
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Command\CommandInterface;
+use GuzzleHttp\Command\Exception\CommandException;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\DescriptionInterface;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
@@ -13,20 +14,21 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Tests\Command\Guzzle\Asset\Exception\CustomCommandException;
 use GuzzleHttp\Tests\Command\Guzzle\Asset\Exception\OtherCustomCommandException;
-use Predis\Response\ResponseInterface;
+use PHPUnit\Framework\MockObject\MockBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\Deserializer
  */
-class DeserializerTest extends \PHPUnit_Framework_TestCase
+class DeserializerTest extends TestCase
 {
-    /** @var ServiceClientInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var ServiceClientInterface|MockBuilder */
     private $serviceClient;
 
-    /** @var CommandInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var CommandInterface|MockBuilder */
     private $command;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->serviceClient = $this->getMockBuilder(GuzzleClient::class)
                             ->disableOriginalConstructor()
@@ -80,11 +82,9 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase
         $client->foo(['bar' => 'baz']);
     }
 
-    /**
-     * @expectedException \GuzzleHttp\Tests\Command\Guzzle\Asset\Exception\CustomCommandException
-     */
     public function testCreateExceptionWithCode()
     {
+        $this->expectException(CustomCommandException::class);
         $response = new Response(404);
         $mock = new MockHandler([$response]);
 
@@ -165,11 +165,9 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase
         $client->foo(['bar' => 'baz']);
     }
 
-    /**
-     * @expectedException \GuzzleHttp\Tests\Command\Guzzle\Asset\Exception\CustomCommandException
-     */
     public function testCreateExceptionWithExactMatchOfReasonPhrase()
     {
+        $this->expectException(CustomCommandException::class);
         $response = new Response(404, [], null, '1.1', 'Bar');
         $mock = new MockHandler([$response]);
 
@@ -209,11 +207,9 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase
         $client->foo(['bar' => 'baz']);
     }
 
-    /**
-     * @expectedException \GuzzleHttp\Tests\Command\Guzzle\Asset\Exception\OtherCustomCommandException
-     */
     public function testFavourMostPreciseMatch()
     {
+        $this->expectException(OtherCustomCommandException::class);
         $response = new Response(404, [], null, '1.1', 'Bar');
         $mock = new MockHandler([$response]);
 
@@ -254,12 +250,10 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase
         $client->foo(['bar' => 'baz']);
     }
 
-    /**
-     * @expectedException \GuzzleHttp\Command\Exception\CommandException
-     * @expectedExceptionMessage 404
-     */
     public function testDoesNotAddResultWhenExceptionIsPresent()
     {
+        $this->expectExceptionMessage("404");
+        $this->expectException(CommandException::class);
         $description = new Description([
             'operations' => [
                 'foo' => [
@@ -381,6 +375,6 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase
                 'content' => 'OK'
             ]
         ];
-        $this->assertArraySubset($expected, $result['LoginResponse']);
+        $this->assertEquals($expected, $result['LoginResponse']);
     }
 }

--- a/tests/GuzzleClientTest.php
+++ b/tests/GuzzleClientTest.php
@@ -10,13 +10,14 @@ use GuzzleHttp\Command\ResultInterface;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\GuzzleClient
  */
-class GuzzleClientTest extends \PHPUnit_Framework_TestCase
+class GuzzleClientTest extends TestCase
 {
     public function testExecuteCommandViaMagicMethod()
     {
@@ -179,8 +180,8 @@ class GuzzleClientTest extends \PHPUnit_Framework_TestCase
 
         $client->doMultiPartLocation(['foo' => 'Foo']);
         $multiPartRequestBody = (string) $mock->getLastRequest()->getBody();
-        $this->assertContains('name="foo"', $multiPartRequestBody);
-        $this->assertContains('Foo', $multiPartRequestBody);
+        $this->assertStringContainsString('name="foo"', $multiPartRequestBody);
+        $this->assertStringContainsString('Foo', $multiPartRequestBody);
 
         $client->doMultiPartLocation([
             'foo' => 'Foo',
@@ -189,20 +190,20 @@ class GuzzleClientTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $multiPartRequestBody = (string) $mock->getLastRequest()->getBody();
-        $this->assertContains('name="foo"', $multiPartRequestBody);
-        $this->assertContains('Foo', $multiPartRequestBody);
-        $this->assertContains('name="bar"', $multiPartRequestBody);
-        $this->assertContains('Bar', $multiPartRequestBody);
-        $this->assertContains('name="baz"', $multiPartRequestBody);
-        $this->assertContains('Baz', $multiPartRequestBody);
+        $this->assertStringContainsString('name="foo"', $multiPartRequestBody);
+        $this->assertStringContainsString('Foo', $multiPartRequestBody);
+        $this->assertStringContainsString('name="bar"', $multiPartRequestBody);
+        $this->assertStringContainsString('Bar', $multiPartRequestBody);
+        $this->assertStringContainsString('name="baz"', $multiPartRequestBody);
+        $this->assertStringContainsString('Baz', $multiPartRequestBody);
 
         $client->doMultiPartLocation([
             'file' => fopen(dirname(__FILE__) . '/Asset/test.html', 'r'),
         ]);
         $multiPartRequestBody = (string) $mock->getLastRequest()->getBody();
-        $this->assertContains('name="file"', $multiPartRequestBody);
-        $this->assertContains('filename="test.html"', $multiPartRequestBody);
-        $this->assertContains('<title>Title</title>', $multiPartRequestBody);
+        $this->assertStringContainsString('name="file"', $multiPartRequestBody);
+        $this->assertStringContainsString('filename="test.html"', $multiPartRequestBody);
+        $this->assertStringContainsString('<title>Title</title>', $multiPartRequestBody);
     }
 
     public function testHasConfig()
@@ -342,12 +343,10 @@ class GuzzleClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    /**
-     * @expectedException \GuzzleHttp\Command\Exception\CommandException
-     * @expectedExceptionMessage Validation errors: [baz] is a required string: baz
-     */
     public function testValidateDescriptionFailsDueMissingRequiredParameter()
     {
+        $this->expectExceptionMessage("Validation errors: [baz] is a required string: baz");
+        $this->expectException(\GuzzleHttp\Command\Exception\CommandException::class);
         $client = new HttpClient();
         $description = new Description(
             [
@@ -421,12 +420,10 @@ class GuzzleClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(200, $result['statusCode']);
     }
 
-    /**
-     * @expectedException \GuzzleHttp\Command\Exception\CommandException
-     * @expectedExceptionMessage Validation errors: [baz] must be of type integer
-     */
     public function testValidateDescriptionFailsDueTypeMismatch()
     {
+        $this->expectExceptionMessage("Validation errors: [baz] must be of type integer");
+        $this->expectException(\GuzzleHttp\Command\Exception\CommandException::class);
         $client = new HttpClient();
         $description = new Description(
             [
@@ -635,12 +632,10 @@ class GuzzleClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $guzzle->foo([]));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage No operation found named Foo
-     */
     public function testThrowsWhenOperationNotFoundInDescription()
     {
+        $this->expectExceptionMessage("No operation found named Foo");
+        $this->expectException(\InvalidArgumentException::class);
         $client = new HttpClient();
         $description = new Description([]);
         $guzzle = new GuzzleClient(

--- a/tests/GuzzleClientTest.php
+++ b/tests/GuzzleClientTest.php
@@ -990,4 +990,48 @@ class GuzzleClientTest extends \PHPUnit_Framework_TestCase
         $result = $guzzle->testing(['foo' => 'bar']);
         $this->assertEquals('bar', $result['args']['foo']);
     }
+
+    public function testDescriptionWithExtends()
+        {
+            $client = new HttpClient();
+            $description = new Description([
+                    'baseUrl' => 'http://httpbin.org/',
+                    'operations' => [
+                        'testing' => [
+                            'httpMethod' => 'GET',
+                            'uri' => '/get',
+                            'responseModel' => 'getResponse',
+                            'parameters' => [
+                                'foo' => [
+                                    'type' => 'string',
+                                    'default' => 'foo',
+                                    'location' => 'query'
+                                ]
+                            ]
+                        ],
+                        'testing_extends' => [
+                            'extends' => 'testing',
+                            'responseModel' => 'getResponse',
+                            'parameters' => [
+                                'bar' => [
+                                    'type' => 'string',
+                                    'location' => 'query'
+                                ]
+                            ]
+                        ],
+                    ],
+                    'models' => [
+                        'getResponse' => [
+                            'type' => 'object',
+                            'additionalProperties' => [
+                                'location' => 'json'
+                            ]
+                        ]
+                    ]
+            ]);
+            $guzzle = new GuzzleClient($client, $description);
+            $result = $guzzle->testing_extends(['bar' => 'bar']);
+            $this->assertEquals('bar', $result['args']['bar']);
+            $this->assertEquals('foo', $result['args']['foo']);
+        }
 }

--- a/tests/Handler/ValidatedDescriptionHandlerTest.php
+++ b/tests/Handler/ValidatedDescriptionHandlerTest.php
@@ -2,7 +2,6 @@
 namespace GuzzleHttp\Tests\Command\Guzzle\Handler;
 
 use GuzzleHttp\Client as HttpClient;
-use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
 
@@ -109,42 +108,5 @@ class ValidatedDescriptionHandlerTest extends \PHPUnit_Framework_TestCase
 
         $client = new GuzzleClient(new HttpClient(), $description);
         $client->foo(['bar' => new \DateTimeImmutable()]); // Should not throw any exception
-    }
-
-    public function testValidationDoesNotMutateCommand()
-    {
-        $description = new Description([
-            'operations' => [
-                'foo' => [
-                    'uri' => 'http://httpbin.org',
-                    'httpMethod' => 'GET',
-                    'parameters' => [
-                        'bar' => [
-                            'location' => 'query',
-                            'type'     => 'string',
-                            'filters'  => ['json_encode'],
-                            'required' => true,
-                        ]
-                    ]
-                ]
-            ]
-        ]);
-
-        $client  = new GuzzleClient(new HttpClient(), $description);
-        $command = new Command('foo', ['bar' => ['baz' => 'bat']]);
-
-        $paramsBeforeValidation = $command->toArray();
-
-        $client->getHandlerStack()->after('validate_description', function (callable $next) use ($paramsBeforeValidation) {
-            return function (Command $command) use ($next, $paramsBeforeValidation) {
-                $paramsAfterValidation = $command->toArray();
-
-                $this->assertSame($paramsBeforeValidation, $paramsAfterValidation);
-
-                return $next($command);
-            };
-        });
-
-        $client->execute($command);
     }
 }

--- a/tests/Handler/ValidatedDescriptionHandlerTest.php
+++ b/tests/Handler/ValidatedDescriptionHandlerTest.php
@@ -4,19 +4,18 @@ namespace GuzzleHttp\Tests\Command\Guzzle\Handler;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\Handler\ValidatedDescriptionHandler
  */
-class ValidatedDescriptionHandlerTest extends \PHPUnit_Framework_TestCase
+class ValidatedDescriptionHandlerTest extends TestCase
 {
 
-    /**
-     * @expectedException \GuzzleHttp\Command\Exception\CommandException
-     * @expectedExceptionMessage Validation errors: [bar] is a required string
-     */
     public function testValidates()
     {
+        $this->expectExceptionMessage("Validation errors: [bar] is a required string");
+        $this->expectException(\GuzzleHttp\Command\Exception\CommandException::class);
         $description = new Description([
             'operations' => [
                 'foo' => [
@@ -59,12 +58,10 @@ class ValidatedDescriptionHandlerTest extends \PHPUnit_Framework_TestCase
         $client->foo([]);
     }
 
-    /**
-     * @expectedException \GuzzleHttp\Command\Exception\CommandException
-     * @expectedExceptionMessage Validation errors: [bar] must be of type string
-     */
     public function testValidatesAdditionalParameters()
     {
+        $this->expectExceptionMessage("Validation errors: [bar] must be of type string");
+        $this->expectException(\GuzzleHttp\Command\Exception\CommandException::class);
         $description = new Description([
             'operations' => [
                 'foo' => [

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -1,13 +1,14 @@
 <?php
-namespace Guzzle\Tests\Service\Description;
+namespace GuzzleHttp\Tests\Command\Guzzle;
 
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\Operation;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\Operation
  */
-class OperationTest extends \PHPUnit_Framework_TestCase
+class OperationTest extends TestCase
 {
     public static function strtoupper($string)
     {
@@ -122,12 +123,10 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => 'baz', 'bar' => 123], $o->getData());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMesssage Parameters must be arrays
-     */
     public function testEnsuresParametersAreArrays()
     {
+        $this->expectExceptionMessage('Parameters must be arrays');
+        $this->expectException(\InvalidArgumentException::class);
         new Operation(['parameters' => ['foo' => true]]);
     }
 

--- a/tests/ParameterTest.php
+++ b/tests/ParameterTest.php
@@ -1,13 +1,14 @@
 <?php
-namespace Guzzle\Tests\Service\Description;
+namespace GuzzleHttp\Tests\Command\Guzzle;
 
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\Parameter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\Parameter
  */
-class ParameterTest extends \PHPUnit_Framework_TestCase
+class ParameterTest extends TestCase
 {
     protected $data = [
         'name'            => 'foo',
@@ -39,11 +40,9 @@ class ParameterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('abc', $p->getName());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testValidatesDescription()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Parameter($this->data, ['description' => 'foo']);
     }
 
@@ -97,12 +96,10 @@ class ParameterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('FOO', $p->filter('foo'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage No service description
-     */
     public function testRequiresServiceDescriptionForFormatting()
     {
+        $this->expectExceptionMessage("No service description");
+        $this->expectException(\RuntimeException::class);
         $d = $this->data;
         $d['format'] = 'foo';
         $p = new Parameter($d);
@@ -137,12 +134,10 @@ class ParameterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $p->getType());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage A [method] value must be specified for each complex filter
-     */
     public function testValidatesComplexFilters()
     {
+        $this->expectExceptionMessage("A [method] value must be specified for each complex filter");
+        $this->expectException(\InvalidArgumentException::class);
         $p = new Parameter(['filters' => [['args' => 'foo']]]);
     }
 
@@ -188,7 +183,7 @@ class ParameterTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('GuzzleHttp\Command\Guzzle\Parameter', $p->getItems());
         $out = $p->toArray();
         $this->assertEquals('array', $out['type']);
-        $this->assertInternalType('array', $out['items']);
+        $this->assertIsArray($out['items']);
     }
 
     public function testCanRetrieveKnownPropertiesUsingDataMethod()
@@ -332,7 +327,7 @@ class ParameterTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($p->getProperty('wefwe'));
 
         $properties = $p->getProperties();
-        $this->assertInternalType('array', $properties);
+        $this->assertIsArray($properties);
         foreach ($properties as $prop) {
             $this->assertInstanceOf('GuzzleHttp\\Command\\Guzzle\\Parameter', $prop);
         }
@@ -340,12 +335,10 @@ class ParameterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($data, $p->toArray());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Expected a string. Got: array
-     */
     public function testThrowsWhenNotPassString()
     {
+        $this->expectExceptionMessage("Expected a string. Got: array");
+        $this->expectException(\InvalidArgumentException::class);
         $emptyParam = new Parameter();
         $this->assertFalse($emptyParam->has([]));
         $this->assertFalse($emptyParam->has(new \stdClass()));

--- a/tests/QuerySerializer/Rfc3986SerializerTest.php
+++ b/tests/QuerySerializer/Rfc3986SerializerTest.php
@@ -2,8 +2,9 @@
 namespace GuzzleHttp\Tests\Command\Guzzle\QuerySerializer;
 
 use GuzzleHttp\Command\Guzzle\QuerySerializer\Rfc3986Serializer;
+use PHPUnit\Framework\TestCase;
 
-class Rfc3986SerializerTest extends \PHPUnit_Framework_TestCase
+class Rfc3986SerializerTest extends TestCase
 {
     public function queryProvider()
     {

--- a/tests/RequestLocation/BodyLocationTest.php
+++ b/tests/RequestLocation/BodyLocationTest.php
@@ -5,11 +5,12 @@ use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\RequestLocation\BodyLocation;
 use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\BodyLocation
  */
-class BodyLocationTest extends \PHPUnit_Framework_TestCase
+class BodyLocationTest extends TestCase
 {
     /**
      * @group RequestLocation

--- a/tests/RequestLocation/FormParamLocationTest.php
+++ b/tests/RequestLocation/FormParamLocationTest.php
@@ -7,12 +7,13 @@ use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\RequestLocation\FormParamLocation;
 use GuzzleHttp\Command\Guzzle\RequestLocation\PostFieldLocation;
 use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\FormParamLocation
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\AbstractLocation
  */
-class FormParamLocationTest extends \PHPUnit_Framework_TestCase
+class FormParamLocationTest extends TestCase
 {
     /**
      * @group RequestLocation
@@ -27,7 +28,7 @@ class FormParamLocationTest extends \PHPUnit_Framework_TestCase
         $operation = new Operation();
         $request = $location->after($command, $request, $operation);
         $this->assertEquals('foo=bar', $request->getBody()->getContents());
-        $this->assertArraySubset([0 => 'application/x-www-form-urlencoded; charset=utf-8'], $request->getHeader('Content-Type'));
+        $this->assertEquals([0 => 'application/x-www-form-urlencoded; charset=utf-8'], $request->getHeader('Content-Type'));
     }
 
     /**

--- a/tests/RequestLocation/HeaderLocationTest.php
+++ b/tests/RequestLocation/HeaderLocationTest.php
@@ -6,12 +6,13 @@ use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\RequestLocation\HeaderLocation;
 use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\HeaderLocation
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\AbstractLocation
  */
-class HeaderLocationTest extends \PHPUnit_Framework_TestCase
+class HeaderLocationTest extends TestCase
 {
     /**
      * @group RequestLocation
@@ -26,7 +27,7 @@ class HeaderLocationTest extends \PHPUnit_Framework_TestCase
 
         $header = $request->getHeader('foo');
         $this->assertTrue(is_array($header));
-        $this->assertArraySubset([0 => 'bar'], $request->getHeader('foo'));
+        $this->assertEquals([0 => 'bar'], $request->getHeader('foo'));
     }
 
     /**
@@ -47,6 +48,6 @@ class HeaderLocationTest extends \PHPUnit_Framework_TestCase
 
         $header = $request->getHeader('add');
         $this->assertTrue(is_array($header));
-        $this->assertArraySubset([0 => 'props'], $header);
+        $this->assertEquals([0 => 'props'], $header);
     }
 }

--- a/tests/RequestLocation/JsonLocationTest.php
+++ b/tests/RequestLocation/JsonLocationTest.php
@@ -6,12 +6,13 @@ use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\RequestLocation\JsonLocation;
 use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\JsonLocation
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\AbstractLocation
  */
-class JsonLocationTest extends \PHPUnit_Framework_TestCase
+class JsonLocationTest extends TestCase
 {
     /**
      * @group RequestLocation
@@ -26,7 +27,7 @@ class JsonLocationTest extends \PHPUnit_Framework_TestCase
         $operation = new Operation();
         $request = $location->after($command, $request, $operation);
         $this->assertEquals('{"foo":"bar"}', $request->getBody()->getContents());
-        $this->assertArraySubset([0 => 'application/json'], $request->getHeader('Content-Type'));
+        $this->assertEquals([0 => 'application/json'], $request->getHeader('Content-Type'));
     }
 
     /**

--- a/tests/RequestLocation/MultiPartLocationTest.php
+++ b/tests/RequestLocation/MultiPartLocationTest.php
@@ -7,11 +7,12 @@ use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\RequestLocation\MultiPartLocation;
 use GuzzleHttp\Command\Guzzle\RequestLocation\PostFileLocation;
 use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\MultiPartLocation
  */
-class MultiPartLocationTest extends \PHPUnit_Framework_TestCase
+class MultiPartLocationTest extends TestCase
 {
     /**
      * @group RequestLocation

--- a/tests/RequestLocation/QueryLocationTest.php
+++ b/tests/RequestLocation/QueryLocationTest.php
@@ -7,12 +7,13 @@ use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\RequestLocation\QueryLocation;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\QueryLocation
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\AbstractLocation
  */
-class QueryLocationTest extends \PHPUnit_Framework_TestCase
+class QueryLocationTest extends TestCase
 {
     public function queryProvider()
     {

--- a/tests/RequestLocation/XmlLocationTest.php
+++ b/tests/RequestLocation/XmlLocationTest.php
@@ -13,11 +13,12 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\RequestLocation\XmlLocation
  */
-class XmlLocationTest extends \PHPUnit_Framework_TestCase
+class XmlLocationTest extends TestCase
 {
     /**
      * @group RequestLocation
@@ -39,7 +40,7 @@ class XmlLocationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('<?xml version="1.0"?>' . "\n"
             . '<Request><foo>bar</foo><bar>test</bar></Request>' . "\n", $xml);
         $header = $request->getHeader('Content-Type');
-        $this->assertArraySubset([0 => 'application/xml'], $header);
+        $this->assertEquals([0 => 'application/xml'], $header);
     }
 
     /**
@@ -59,7 +60,7 @@ class XmlLocationTest extends \PHPUnit_Framework_TestCase
             . '<Request/>' . "\n", $xml);
 
         $header = $request->getHeader('Content-Type');
-        $this->assertArraySubset([0 => 'application/xml'], $header);
+        $this->assertEquals([0 => 'application/xml'], $header);
     }
 
     /**
@@ -84,7 +85,7 @@ class XmlLocationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('<?xml version="1.0"?>' . "\n"
             . '<Request><foo>bar</foo><foo>bar</foo><bam>boo</bam></Request>' . "\n", $xml);
         $header = $request->getHeader('Content-Type');
-        $this->assertArraySubset([0 => 'test'], $header);
+        $this->assertEquals([0 => 'test'], $header);
     }
 
     /**
@@ -512,10 +513,10 @@ class XmlLocationTest extends \PHPUnit_Framework_TestCase
             $request = $transaction['request'];
             if (empty($input)) {
                 if ($request->hasHeader('Content-Type')) {
-                    $this->assertArraySubset([0 => ''], $request->getHeader('Content-Type'));
+                    $this->assertEquals([0 => ''], $request->getHeader('Content-Type'));
                 }
             } else {
-                $this->assertArraySubset([0 => 'application/xml'], $request->getHeader('Content-Type'));
+                $this->assertEquals([0 => 'application/xml'], $request->getHeader('Content-Type'));
             }
 
             $body = str_replace(["\n", "<?xml version=\"1.0\"?>"], '', (string) $request->getBody());

--- a/tests/ResponseLocation/BodyLocationTest.php
+++ b/tests/ResponseLocation/BodyLocationTest.php
@@ -5,12 +5,13 @@ use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\ResponseLocation\BodyLocation;
 use GuzzleHttp\Command\Result;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\BodyLocation
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\AbstractLocation
  */
-class BodyLocationTest extends \PHPUnit_Framework_TestCase
+class BodyLocationTest extends TestCase
 {
     /**
      * @group ResponseLocation

--- a/tests/ResponseLocation/HeaderLocationTest.php
+++ b/tests/ResponseLocation/HeaderLocationTest.php
@@ -5,12 +5,13 @@ use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\ResponseLocation\HeaderLocation;
 use GuzzleHttp\Command\Result;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\HeaderLocation
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\AbstractLocation
  */
-class HeaderLocationTest extends \PHPUnit_Framework_TestCase
+class HeaderLocationTest extends TestCase
 {
     /**
      * @group ResponseLocation

--- a/tests/ResponseLocation/JsonLocationTest.php
+++ b/tests/ResponseLocation/JsonLocationTest.php
@@ -10,12 +10,13 @@ use GuzzleHttp\Command\Result;
 use GuzzleHttp\Command\ResultInterface;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\JsonLocation
  * @covers \GuzzleHttp\Command\Guzzle\Deserializer
  */
-class JsonLocationTest extends \PHPUnit_Framework_TestCase
+class JsonLocationTest extends TestCase
 {
 
     /**

--- a/tests/ResponseLocation/ReasonPhraseLocationTest.php
+++ b/tests/ResponseLocation/ReasonPhraseLocationTest.php
@@ -5,12 +5,13 @@ use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\ResponseLocation\ReasonPhraseLocation;
 use GuzzleHttp\Command\Result;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\ReasonPhraseLocation
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\AbstractLocation
  */
-class ReasonPhraseLocationTest extends \PHPUnit_Framework_TestCase
+class ReasonPhraseLocationTest extends TestCase
 {
     /**
      * @group ResponseLocation

--- a/tests/ResponseLocation/StatusCodeLocationTest.php
+++ b/tests/ResponseLocation/StatusCodeLocationTest.php
@@ -5,12 +5,13 @@ use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\ResponseLocation\StatusCodeLocation;
 use GuzzleHttp\Command\Result;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\StatusCodeLocation
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\AbstractLocation
  */
-class StatusCodeLocationTest extends \PHPUnit_Framework_TestCase
+class StatusCodeLocationTest extends TestCase
 {
     /**
      * @group ResponseLocation

--- a/tests/ResponseLocation/XmlLocationTest.php
+++ b/tests/ResponseLocation/XmlLocationTest.php
@@ -5,11 +5,12 @@ use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\ResponseLocation\XmlLocation;
 use GuzzleHttp\Command\Result;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\ResponseLocation\XmlLocation
  */
-class XmlLocationTest extends \PHPUnit_Framework_TestCase
+class XmlLocationTest extends TestCase
 {
     /**
      * @group ResponseLocation

--- a/tests/SchemaFormatterTest.php
+++ b/tests/SchemaFormatterTest.php
@@ -2,11 +2,12 @@
 namespace GuzzleHttp\Tests\Command\Guzzle;
 
 use GuzzleHttp\Command\Guzzle\SchemaFormatter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\SchemaFormatter
  */
-class SchemaFormatterTest extends \PHPUnit_Framework_TestCase
+class SchemaFormatterTest extends TestCase
 {
     public function dateTimeProvider()
     {
@@ -42,11 +43,9 @@ class SchemaFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($result, (new SchemaFormatter)->format($format, $value));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testValidatesDateTimeInput()
     {
+        $this->expectException(\InvalidArgumentException::class);
         (new SchemaFormatter)->format('date-time', false);
     }
 
@@ -55,6 +54,6 @@ class SchemaFormatterTest extends \PHPUnit_Framework_TestCase
         $t = time();
         $result = (new SchemaFormatter)->format('timestamp', $t);
         $this->assertSame($t, $result);
-        $this->assertInternalType('int', $result);
+        $this->assertIsInt($result);
     }
 }

--- a/tests/SchemaValidatorTest.php
+++ b/tests/SchemaValidatorTest.php
@@ -4,16 +4,17 @@ namespace Guzzle\Tests\Service\Description;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\SchemaValidator;
 use GuzzleHttp\Command\ToArrayInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\SchemaValidator
  */
-class SchemaValidatorTest extends \PHPUnit_Framework_TestCase
+class SchemaValidatorTest extends TestCase
 {
     /** @var SchemaValidator */
     protected $validator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->validator = new SchemaValidator();
     }
@@ -65,7 +66,7 @@ class SchemaValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $param = $this->getComplexParam();
         $result = $param->toArray();
-        $this->assertInternalType('array', $result['items']);
+        $this->assertIsArray($result['items']);
         $this->assertEquals('array', $result['type']);
         $this->assertInstanceOf('GuzzleHttp\Command\Guzzle\Parameter', $param->getItems());
     }

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -5,11 +5,12 @@ use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\Serializer;
 use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\Serializer
  */
-class SerializerTest extends \PHPUnit_Framework_TestCase
+class SerializerTest extends TestCase
 {
     public function testAllowsUriTemplates()
     {


### PR DESCRIPTION
Guzzle 7 support

- Updated phpunit version
- Updated guzzle 7

The minimum PHP version is now 7.3