### PR TITLE
Fix `http_build_query` on PHP 8.1

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="true"
-    colors="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="vendor/autoload.php"
+    colors="true"
+    convertDeprecationsToExceptions="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
 >
     <testsuites>
         <testsuite name="unit">

--- a/src/QuerySerializer/Rfc3986Serializer.php
+++ b/src/QuerySerializer/Rfc3986Serializer.php
@@ -22,7 +22,7 @@ class Rfc3986Serializer implements QuerySerializerInterface
      */
     public function aggregate(array $queryParams)
     {
-        $queryString = http_build_query($queryParams, null, '&', PHP_QUERY_RFC3986);
+        $queryString = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
 
         if ($this->removeNumericIndices) {
             $queryString = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $queryString);


### PR DESCRIPTION
http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated

https://www.php.net/manual/en/function.http-build-query.php#refsect1-function.http-build-query-description