### PR TITLE
Update Parameter.php

### DIFF
--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -177,8 +177,6 @@ class Parameter implements ToArrayInterface
      */
     public function __construct(array $data = [], array $options = [])
     {
-        $this->originalData = $data;
-
         if (isset($options['description'])) {
             $this->serviceDescription = $options['description'];
             if (!($this->serviceDescription instanceof DescriptionInterface)) {
@@ -202,6 +200,9 @@ class Parameter implements ToArrayInterface
             }
         }
 
+        // Set data after extend to allow nested models to pass properties
+        $this->originalData = $data;
+        
         // Pull configuration data into the parameter
         foreach ($data as $key => $value) {
             $this->{$key} = $value;


### PR DESCRIPTION
Set $data to originalData after extend to allow nested models that are extended by other models to pass properties through to parents, per issue 184 (https://github.com/guzzle/guzzle-services/issues/184).