### PR TITLE
Compatible with PHP8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: 'none'
           extensions: mbstring
+          ini-values: error_reporting=E_ALL
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/src/ResponseLocation/XmlLocation.php
+++ b/src/ResponseLocation/XmlLocation.php
@@ -80,7 +80,7 @@ class XmlLocation extends AbstractLocation
     ) {
         $sentAs = $param->getWireName();
         $ns = null;
-        if (strstr($sentAs, ':')) {
+        if (strstr($sentAs ?: '', ':')) {
             list($ns, $sentAs) = explode(':', $sentAs);
         }
 
@@ -144,7 +144,7 @@ class XmlLocation extends AbstractLocation
         $result = [];
         $ns = null;
 
-        if (strstr($sentAs ?? '', ':')) {
+        if (strstr($sentAs ?: '', ':')) {
             // Get namespace from the wire name
             list($ns, $sentAs) = explode(':', $sentAs);
         } else {

--- a/src/ResponseLocation/XmlLocation.php
+++ b/src/ResponseLocation/XmlLocation.php
@@ -80,7 +80,7 @@ class XmlLocation extends AbstractLocation
     ) {
         $sentAs = $param->getWireName();
         $ns = null;
-        if (strstr($sentAs ?: '', ':')) {
+        if (null !== $sentAs && strstr($sentAs, ':')) {
             list($ns, $sentAs) = explode(':', $sentAs);
         }
 
@@ -144,7 +144,7 @@ class XmlLocation extends AbstractLocation
         $result = [];
         $ns = null;
 
-        if (strstr($sentAs ?: '', ':')) {
+        if (null !== $sentAs && strstr($sentAs, ':')) {
             // Get namespace from the wire name
             list($ns, $sentAs) = explode(':', $sentAs);
         } else {

--- a/src/ResponseLocation/XmlLocation.php
+++ b/src/ResponseLocation/XmlLocation.php
@@ -144,7 +144,7 @@ class XmlLocation extends AbstractLocation
         $result = [];
         $ns = null;
 
-        if (strstr($sentAs, ':')) {
+        if (strstr($sentAs ?? '', ':')) {
             // Get namespace from the wire name
             list($ns, $sentAs) = explode(':', $sentAs);
         } else {


### PR DESCRIPTION
Fix https://github.com/tencentyun/cos-php-sdk-v5/issues/290

```
\vendor\guzzlehttp\guzzle-services\src\ResponseLocation\XmlLocation.php line 147:
strstr(): Passing null to parameter #1 ($haystack) of type string is deprecated
```