### PR TITLE
Add default property into response model

### DIFF
--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -152,6 +152,8 @@ class JsonLocation extends AbstractLocation
                         );
                         // Remove from the value so that AP can later be handled
                         unset($value[$key]);
+                    } elseif (array_key_exists('default', $property->toArray())) {
+                      $result[$property->getName()] = $property->getDefault();
                     }
                 }
             }


### PR DESCRIPTION
Currently, if a property that is in the model doesn't exist in the returned results set, it returns nothing, regardless of if a default is provided or not. It seems rational to not return a value in the model that doesn't exist, which allows someone to understand what is coming from the API or not. But I think there are benefits to allowing someone to set default on a property and allow the model to return that in the situation that the value wasn't set in the original response. By checking whether a default is set in general, regardless of if it is truthy, falsey, or whatever else, this supports backwards compatibility with the option to 'opt in' to setting a default for a property.