### PR TITLE
Fix when multipart has body of multipart stream

### DIFF
--- a/src/RequestLocation/MultiPartLocation.php
+++ b/src/RequestLocation/MultiPartLocation.php
@@ -62,7 +62,7 @@ class MultiPartLocation extends AbstractLocation
         $request = Psr7\Utils::modifyRequest($request, $modify);
         if ($request->getBody() instanceof Psr7\MultipartStream) {
             // Use a multipart/form-data POST if a Content-Type is not set.
-            $request->withHeader('Content-Type', $this->contentType.$request->getBody()->getBoundary());
+            $request = $request->withHeader('Content-Type', $this->contentType.$request->getBody()->getBoundary());
         }
 
         return $request;

--- a/tests/RequestLocation/MultiPartLocationTest.php
+++ b/tests/RequestLocation/MultiPartLocationTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\RequestLocation\MultiPartLocation;
+use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
 
@@ -30,5 +31,24 @@ class MultiPartLocationTest extends TestCase
 
         $this->assertNotFalse(strpos($actual, 'name="foo"'));
         $this->assertNotFalse(strpos($actual, 'bar'));
+    }
+
+    /**
+     * @group RequestLocation
+     */
+    public function testVisitsLocationWhenBodyIsMultipartStream()
+    {
+        $location = new MultiPartLocation();
+        $command = new Command('foo', ['foo' => 'bar']);
+        $request = new Request('POST', 'http://httbin.org', [], new MultipartStream());
+        $param = new Parameter(['name' => 'foo']);
+        $request = $location->visit($command, $request, $param);
+        $operation = new Operation();
+        $request = $location->after($command, $request, $operation);
+        $actual = $request->getBody()->getContents();
+
+        $this->assertNotFalse(strpos($actual, 'name="foo"'));
+        $this->assertNotFalse(strpos($actual, 'bar'));
+        $this->assertStringContainsString('multipart/form-data;', $request->getHeader('Content-Type')[0]);
     }
 }


### PR DESCRIPTION
Problem happens, when I try to use multipart.

Example:
```
    "PostTicketRequest": {
      "httpMethod": "POST",
      "uri": "/api/...",
      "summary": "Posts ticket request",
      "responseModel": "Response",
      "parameters": {
        "description": {
          "location": "multipart",
          "type": "string",
          "required": true
        },
        ....
```

The correct header is not added, since request is  immutable object. So we need to assign a variable. Which was missed.