### PR TITLE
Update CI workflows and add PHPStan

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,11 +11,11 @@ permissions:
 jobs:
   composer-normalize:
     name: Composer Normalize
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Composer normalize
         uses: docker://ergebnis/composer-normalize-action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build-lowest-version:
     name: Build lowest version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Set up PHP
@@ -23,7 +23,7 @@ jobs:
           extensions: mbstring
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: composer update --no-interaction --prefer-stable --prefer-lowest --no-progress
@@ -33,11 +33,11 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       max-parallel: 10
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Set up PHP
@@ -49,7 +49,7 @@ jobs:
           extensions: mbstring
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: composer update --no-interaction --no-progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       max-parallel: 10
       matrix:
         php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -9,13 +9,37 @@ permissions:
   contents: read
 
 jobs:
-  php-cs-fixer:
-    name: PHP-CS-Fixer
-    runs-on: ubuntu-22.04
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+          extensions: mbstring
+
+      - name: Download dependencies
+        run: composer update --no-interaction --no-progress
+
+      - name: Download PHPStan
+        run: composer bin phpstan update --no-interaction --no-progress
+
+      - name: Execute PHPStan
+        run: vendor/bin/phpstan analyze --no-progress
+
+  php-cs-fixer:
+    name: PHP-CS-Fixer
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -23,7 +47,6 @@ jobs:
           php-version: '7.4'
           coverage: none
           extensions: mbstring
-          tools: composer
 
       - name: Download dependencies
         run: composer update --no-interaction --no-progress

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,157 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: src/Deserializer.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$request with type Psr\\Http\\Message\\RequestInterface\|null is not subtype of native type Psr\\Http\\Message\\RequestInterface\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: src/Deserializer.php
+
+		-
+			message: '#^Method GuzzleHttp\\Command\\Guzzle\\Operation\:\:getServiceDescription\(\) should return GuzzleHttp\\Command\\Guzzle\\Description but returns GuzzleHttp\\Command\\Guzzle\\DescriptionInterface\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Operation.php
+
+		-
+			message: '#^Call to function is_object\(\) with \*NEVER\* will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Parameter.php
+
+		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Parameter.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 2
+			path: src/Parameter.php
+
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: src/Parameter.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: src/Parameter.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: src/Parameter.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 3
+			path: src/Parameter.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 1
+			path: src/RequestLocation/AbstractLocation.php
+
+		-
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
+			count: 1
+			path: src/RequestLocation/HeaderLocation.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 2
+			path: src/RequestLocation/XmlLocation.php
+
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: src/RequestLocation/XmlLocation.php
+
+		-
+			message: '#^Parameter \#1 \$name of method GuzzleHttp\\Command\\Guzzle\\Parameter\:\:setName\(\) expects string, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/RequestLocation/XmlLocation.php
+
+		-
+			message: '#^Property GuzzleHttp\\Command\\Guzzle\\RequestLocation\\XmlLocation\:\:\$writer \(XMLWriter\) does not accept null\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/RequestLocation/XmlLocation.php
+
+		-
+			message: '#^Call to function is_array\(\) with non\-empty\-array\<string\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/ResponseLocation/HeaderLocation.php
+
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: src/ResponseLocation/XmlLocation.php
+
+		-
+			message: '#^Property GuzzleHttp\\Command\\Guzzle\\ResponseLocation\\XmlLocation\:\:\$xml \(SimpleXMLElement\) does not accept null\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/ResponseLocation/XmlLocation.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between null and string will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 2
+			path: src/ResponseLocation/XmlLocation.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: src/ResponseLocation/XmlLocation.php
+
+		-
+			message: '#^Variable \$result in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/ResponseLocation/XmlLocation.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: src/SchemaFormatter.php
+
+		-
+			message: '#^Parameter \#1 \$array of function sort contains unresolvable type\.$#'
+			identifier: argument.unresolvableType
+			count: 1
+			path: src/SchemaValidator.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between null and string will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: src/Serializer.php
+
+		-
+			message: '#^Variable \$additional in PHPDoc tag @var does not exist\.$#'
+			identifier: varTag.variableNotFound
+			count: 1
+			path: src/Serializer.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -115,18 +115,6 @@ parameters:
 			path: src/ResponseLocation/XmlLocation.php
 
 		-
-			message: '#^Strict comparison using \!\=\= between null and string will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 2
-			path: src/ResponseLocation/XmlLocation.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between string and null will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: src/ResponseLocation/XmlLocation.php
-
-		-
 			message: '#^Variable \$result in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 1

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - src

--- a/src/Description.php
+++ b/src/Description.php
@@ -143,7 +143,7 @@ class Description implements DescriptionInterface
         }
 
         // Lazily create operations as they are retrieved
-        if (!($this->operations[$name] instanceof Operation)) {
+        if (!$this->operations[$name] instanceof Operation) {
             $this->operations[$name]['name'] = $name;
             $this->operations[$name] = new Operation($this->operations[$name], $this);
         }
@@ -167,7 +167,7 @@ class Description implements DescriptionInterface
         }
 
         // Lazily create models as they are retrieved
-        if (!($this->models[$id] instanceof Parameter)) {
+        if (!$this->models[$id] instanceof Parameter) {
             $this->models[$id] = new Parameter(
                 $this->models[$id],
                 ['description' => $this]
@@ -261,8 +261,8 @@ class Description implements DescriptionInterface
             return $this->extraData;
         } elseif (isset($this->extraData[$key])) {
             return $this->extraData[$key];
-        } else {
-            return null;
         }
+
+        return null;
     }
 }

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -252,9 +252,9 @@ class Operation implements ToArrayInterface
             return $this->config['data'];
         } elseif (isset($this->config['data'][$name])) {
             return $this->config['data'][$name];
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -183,7 +183,7 @@ class Parameter implements ToArrayInterface
 
         if (isset($options['description'])) {
             $this->serviceDescription = $options['description'];
-            if (!($this->serviceDescription instanceof DescriptionInterface)) {
+            if (!$this->serviceDescription instanceof DescriptionInterface) {
                 throw new \InvalidArgumentException('description must be a Description');
             }
             if (isset($data['$ref'])) {
@@ -524,7 +524,7 @@ class Parameter implements ToArrayInterface
             return null;
         }
 
-        if (!($this->properties[$name] instanceof self)) {
+        if (!$this->properties[$name] instanceof self) {
             $this->properties[$name]['name'] = $name;
             $this->properties[$name] = new static(
                 $this->properties[$name],

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -12,7 +12,7 @@ class Parameter implements ToArrayInterface
 {
     private $originalData;
 
-    /** @var string */
+    /** @var string|null */
     private $name;
 
     /** @var string */
@@ -60,7 +60,7 @@ class Parameter implements ToArrayInterface
     /** @var string */
     private $location;
 
-    /** @var string */
+    /** @var string|null */
     private $sentAs;
 
     /** @var array */
@@ -303,7 +303,7 @@ class Parameter implements ToArrayInterface
     /**
      * Get the name of the parameter
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -324,7 +324,7 @@ class Parameter implements ToArrayInterface
      * Get the key of the parameter, where sentAs will supersede name if it is
      * set.
      *
-     * @return string
+     * @return string|null
      */
     public function getWireName()
     {

--- a/src/RequestLocation/XmlLocation.php
+++ b/src/RequestLocation/XmlLocation.php
@@ -203,11 +203,11 @@ class XmlLocation extends AbstractLocation
     /**
      * Write an element with namespace if used
      *
-     * @param \XMLWriter $writer    XML writer resource
-     * @param string     $prefix    Namespace prefix if any
-     * @param string     $name      Element name
-     * @param string     $namespace The uri of the namespace
-     * @param string     $value     The element content
+     * @param \XMLWriter  $writer    XML writer resource
+     * @param string      $prefix    Namespace prefix if any
+     * @param string      $name      Element name
+     * @param string      $namespace The uri of the namespace
+     * @param string|null $value     The element content
      */
     protected function writeElement(\XMLWriter $writer, $prefix, $name, $namespace, $value)
     {

--- a/src/RequestLocation/XmlLocation.php
+++ b/src/RequestLocation/XmlLocation.php
@@ -152,7 +152,7 @@ class XmlLocation extends AbstractLocation
         $name = $param->getWireName();
         $prefix = null;
         $namespace = $param->getData('xmlNamespace');
-        if (false !== strpos($name, ':')) {
+        if ($name !== null && false !== strpos($name, ':')) {
             list($prefix, $name) = explode(':', $name, 2);
         }
 
@@ -216,7 +216,7 @@ class XmlLocation extends AbstractLocation
         } else {
             $writer->startElement($name);
         }
-        if (strpbrk($value, '<>&')) {
+        if ($value !== null && strpbrk($value, '<>&')) {
             $writer->writeCData($value);
         } else {
             $writer->writeRaw($value);

--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -102,7 +102,7 @@ class JsonLocation extends AbstractLocation
                     $this->recurse($param, $this->json)
                 ));
             }
-        } elseif (isset($this->json[$key])) {
+        } elseif ($key !== null && isset($this->json[$key])) {
             $result[$name] = $this->recurse($param, $this->json[$key]);
         }
 

--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -55,7 +55,7 @@ class JsonLocation extends AbstractLocation
     ) {
         // Handle additional, undefined properties
         $additional = $model->getAdditionalProperties();
-        if (!($additional instanceof Parameter)) {
+        if (!$additional instanceof Parameter) {
             return $result;
         }
 

--- a/src/ResponseLocation/XmlLocation.php
+++ b/src/ResponseLocation/XmlLocation.php
@@ -177,8 +177,10 @@ class XmlLocation extends AbstractLocation
             foreach ($properties as $property) {
                 $name = $property->getName();
                 $sentAs = $property->getWireName();
-                $knownProps[$sentAs] = 1;
-                if (strpos($sentAs, ':')) {
+                if ($sentAs !== null) {
+                    $knownProps[$sentAs] = 1;
+                }
+                if ($sentAs !== null && strpos($sentAs, ':')) {
                     list($ns, $sentAs) = explode(':', $sentAs);
                 } else {
                     $ns = $property->getData('xmlNs');

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -40,11 +40,10 @@ class SchemaValidator
 
         if (empty($this->errors)) {
             return true;
-        } else {
-            sort($this->errors);
-
-            return false;
         }
+        sort($this->errors);
+
+        return false;
     }
 
     /**

--- a/tests/SchemaValidatorTest.php
+++ b/tests/SchemaValidatorTest.php
@@ -200,7 +200,9 @@ class SchemaValidatorTest extends TestCase
     {
         $p = new SchemaValidator();
         $r = new \ReflectionMethod($p, 'determineType');
-        $r->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $r->setAccessible(true);
+        }
         $this->assertEquals('any', $r->invoke($p, 'any', 'hello'));
         $this->assertEquals(false, $r->invoke($p, 'foo', 'foo'));
         $this->assertEquals('string', $r->invoke($p, 'string', 'hello'));

--- a/vendor-bin/php-cs-fixer/composer.json
+++ b/vendor-bin/php-cs-fixer/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
-        "php": "^7.4 || ^8.0",
-        "friendsofphp/php-cs-fixer": "3.68.5"
+        "php": "^7.4",
+        "friendsofphp/php-cs-fixer": "3.94.2"
     },
     "config": {
         "preferred-install": "dist"

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,0 +1,10 @@
+{
+    "require": {
+        "php": "^8.2",
+        "phpstan/phpstan": "2.1.40",
+        "phpstan/phpstan-deprecation-rules": "2.0.3"
+    },
+    "config": {
+        "preferred-install": "dist"
+    }
+}


### PR DESCRIPTION
## Summary
- Standardize all workflow files: ubuntu-24.04, actions/checkout@v6, PHP 8.5 in matrix
- Add PHPStan (level 5) with baseline
- Upgrade php-cs-fixer to 3.94.2 and apply fixes
- Upgrade bamarni/composer-bin-plugin to 1.9.1

## Test plan
- [ ] CI passes: checks, static analysis, and tests