### PR TITLE
Use local test server in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
           coverage: 'none'
           extensions: mbstring
 
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+
       - name: Checkout code
         uses: actions/checkout@v6
 
@@ -48,6 +53,11 @@ jobs:
           ini-values: error_reporting=E_ALL
           coverage: 'none'
           extensions: mbstring
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
 
       - name: Checkout code
         uses: actions/checkout@v6

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",
+        "guzzlehttp/test-server": "^0.3.2",
         "phpunit/phpunit": "^8.5.52 || ^9.6.34"
     },
     "suggest": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
     backupGlobals="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    bootstrap="vendor/autoload.php"
+    bootstrap="tests/bootstrap.php"
     colors="true"
     convertDeprecationsToExceptions="true"
     convertErrorsToExceptions="true"

--- a/tests/GuzzleClientTest.php
+++ b/tests/GuzzleClientTest.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Command\ResultInterface;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Server\Server;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -276,7 +277,7 @@ class GuzzleClientTest extends TestCase
         $description = new Description(
             [
                 'name' => 'Testing API ',
-                'baseUri' => 'http://httpbin.org/',
+                'baseUri' => Server::$url,
                 'operations' => [
                     'Foo' => [
                         'httpMethod' => 'GET',
@@ -325,6 +326,9 @@ class GuzzleClientTest extends TestCase
             ]
         );
 
+        Server::flush();
+        Server::enqueue([new Response(200)]);
+
         $guzzle = new GuzzleClient(
             $client,
             $description,
@@ -342,6 +346,12 @@ class GuzzleClientTest extends TestCase
         $response = $guzzle->execute($command);
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(200, $response->getStatusCode());
+
+        $requests = Server::received();
+        $this->assertCount(1, $requests);
+        $query = [];
+        parse_str($requests[0]->getUri()->getQuery(), $query);
+        $this->assertSame('BAZ', $query['baz']);
     }
 
     public function testValidateDescriptionFailsDueMissingRequiredParameter()
@@ -504,7 +514,7 @@ class GuzzleClientTest extends TestCase
         $description = new Description(
             [
                 'name' => 'Testing API ',
-                'baseUri' => 'http://httpbin.org/',
+                'baseUri' => Server::$url,
                 'operations' => [
                     'Foo' => [
                         'httpMethod' => 'GET',
@@ -553,6 +563,9 @@ class GuzzleClientTest extends TestCase
             ]
         );
 
+        Server::flush();
+        Server::enqueue([new Response(200)]);
+
         $guzzle = new GuzzleClient($client, $description);
 
         $command = $guzzle->getCommand('Foo', ['baz' => 42]);
@@ -561,6 +574,12 @@ class GuzzleClientTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $result = $result->toArray();
         $this->assertEquals(200, $result['statusCode']);
+
+        $requests = Server::received();
+        $this->assertCount(1, $requests);
+        $query = [];
+        parse_str($requests[0]->getUri()->getQuery(), $query);
+        $this->assertSame('42', $query['baz']);
     }
 
     public function testMagicMethodExecutesCommands()
@@ -655,7 +674,7 @@ class GuzzleClientTest extends TestCase
         $description = new Description(
             [
                 'name' => 'Testing API ',
-                'baseUri' => 'http://httpbin.org/',
+                'baseUri' => Server::$url,
                 'operations' => [
                     'Foo' => [
                         'httpMethod' => 'GET',
@@ -704,6 +723,9 @@ class GuzzleClientTest extends TestCase
             ]
         );
 
+        Server::flush();
+        Server::enqueue([new Response(200)]);
+
         $guzzle = new GuzzleClient($client, $description, null, null);
         $command = $guzzle->getCommand('foo', ['baz' => 'BAZ']);
 
@@ -712,6 +734,12 @@ class GuzzleClientTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $result = $result->toArray();
         $this->assertEquals(200, $result['statusCode']);
+
+        $requests = Server::received();
+        $this->assertCount(1, $requests);
+        $query = [];
+        parse_str($requests[0]->getUri()->getQuery(), $query);
+        $this->assertSame('BAZ', $query['baz']);
     }
 
     private function getServiceClient(
@@ -953,7 +981,7 @@ class GuzzleClientTest extends TestCase
     {
         $client = new HttpClient();
         $description = new Description([
-            'baseUrl' => 'http://httpbin.org/',
+            'baseUrl' => Server::$url,
             'operations' => [
                 'testing' => [
                     'httpMethod' => 'GET',
@@ -983,15 +1011,24 @@ class GuzzleClientTest extends TestCase
 
         $guzzle = new GuzzleClient($client, $description);
 
+        Server::flush();
+        Server::enqueue([new Response(200, [], '{"args":{"foo":"bar"}}')]);
+
         $result = $guzzle->testing(['foo' => 'bar']);
         $this->assertEquals('bar', $result['args']['foo']);
+
+        $requests = Server::received();
+        $this->assertCount(1, $requests);
+        $query = [];
+        parse_str($requests[0]->getUri()->getQuery(), $query);
+        $this->assertSame('bar', $query['foo']);
     }
 
     public function testDescriptionWithExtends()
     {
         $client = new HttpClient();
         $description = new Description([
-            'baseUrl' => 'http://httpbin.org/',
+            'baseUrl' => Server::$url,
             'operations' => [
                 'testing' => [
                     'httpMethod' => 'GET',
@@ -1026,8 +1063,19 @@ class GuzzleClientTest extends TestCase
             ],
         ]);
         $guzzle = new GuzzleClient($client, $description);
+
+        Server::flush();
+        Server::enqueue([new Response(200, [], '{"args":{"foo":"foo","bar":"bar"}}')]);
+
         $result = $guzzle->testing_extends(['bar' => 'bar']);
         $this->assertEquals('bar', $result['args']['bar']);
         $this->assertEquals('foo', $result['args']['foo']);
+
+        $requests = Server::received();
+        $this->assertCount(1, $requests);
+        $query = [];
+        parse_str($requests[0]->getUri()->getQuery(), $query);
+        $this->assertSame('bar', $query['bar']);
+        $this->assertSame('foo', $query['foo']);
     }
 }

--- a/tests/Handler/ValidatedDescriptionHandlerTest.php
+++ b/tests/Handler/ValidatedDescriptionHandlerTest.php
@@ -6,6 +6,8 @@ use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
 use GuzzleHttp\Command\Result;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Server\Server;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,7 +22,7 @@ class ValidatedDescriptionHandlerTest extends TestCase
         $description = new Description([
             'operations' => [
                 'foo' => [
-                    'uri' => 'http://httpbin.org',
+                    'uri' => Server::$url,
                     'httpMethod' => 'GET',
                     'responseModel' => 'j',
                     'parameters' => [
@@ -42,7 +44,7 @@ class ValidatedDescriptionHandlerTest extends TestCase
         $description = new Description([
             'operations' => [
                 'foo' => [
-                    'uri' => 'http://httpbin.org',
+                    'uri' => Server::$url,
                     'httpMethod' => 'GET',
                     'responseModel' => 'j',
                     'parameters' => [],
@@ -55,6 +57,9 @@ class ValidatedDescriptionHandlerTest extends TestCase
             ],
         ]);
 
+        Server::flush();
+        Server::enqueue([new Response(200)]);
+
         $client = new GuzzleClient(new HttpClient(), $description);
         self::assertInstanceOf(Result::class, $client->foo([]));
     }
@@ -66,7 +71,7 @@ class ValidatedDescriptionHandlerTest extends TestCase
         $description = new Description([
             'operations' => [
                 'foo' => [
-                    'uri' => 'http://httpbin.org',
+                    'uri' => Server::$url,
                     'httpMethod' => 'GET',
                     'responseModel' => 'j',
                     'additionalParameters' => [
@@ -90,7 +95,7 @@ class ValidatedDescriptionHandlerTest extends TestCase
         $description = new Description([
             'operations' => [
                 'foo' => [
-                    'uri' => 'http://httpbin.org',
+                    'uri' => Server::$url,
                     'httpMethod' => 'GET',
                     'parameters' => [
                         'bar' => [
@@ -103,6 +108,9 @@ class ValidatedDescriptionHandlerTest extends TestCase
                 ],
             ],
         ]);
+
+        Server::flush();
+        Server::enqueue([new Response(200)]);
 
         $client = new GuzzleClient(new HttpClient(), $description);
         // Should not throw any exception

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Server\Server;
+
+require __DIR__.'/../vendor/autoload.php';
+
+$port = getenv('GUZZLE_SERVICES_TEST_SERVER_PORT');
+if ($port !== false && $port !== '') {
+    Server::$port = (int) $port;
+    Server::$url = 'http://127.0.0.1:'.Server::$port.'/';
+}
+
+Server::start();
+
+register_shutdown_function(static function (): void {
+    try {
+        Server::stop();
+    } catch (Exception $e) {
+        // The process may already have been stopped by a local developer.
+    }
+});


### PR DESCRIPTION
## Summary
- add guzzlehttp/test-server and start it from the PHPUnit bootstrap
- point live HTTP test cases at the local queued test server instead of httpbin.org
- set up Node 22 in CI so the shared test server can run

## Testing
- Not run locally per request; relying on CI
- Ran Composer dependency update inside the PHP 7.4 Docker image