### PR TITLE
Fix multipart Content-Type header

### DIFF
--- a/src/RequestLocation/MultiPartLocation.php
+++ b/src/RequestLocation/MultiPartLocation.php
@@ -60,9 +60,9 @@ class MultiPartLocation extends AbstractLocation
         $body = new Psr7\MultipartStream($data);
         $modify['body'] = Psr7\Utils::streamFor($body);
         $request = Psr7\Utils::modifyRequest($request, $modify);
-        if ($request->getBody() instanceof Psr7\MultipartStream) {
+        if ($request->getBody() instanceof Psr7\MultipartStream && !$request->hasHeader('Content-Type')) {
             // Use a multipart/form-data POST if a Content-Type is not set.
-            $request->withHeader('Content-Type', $this->contentType.$request->getBody()->getBoundary());
+            $request = $request->withHeader('Content-Type', $this->contentType.$request->getBody()->getBoundary());
         }
 
         return $request;

--- a/tests/RequestLocation/MultiPartLocationTest.php
+++ b/tests/RequestLocation/MultiPartLocationTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\RequestLocation\MultiPartLocation;
+use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
 
@@ -26,9 +27,31 @@ class MultiPartLocationTest extends TestCase
         $request = $location->visit($command, $request, $param);
         $operation = new Operation();
         $request = $location->after($command, $request, $operation);
+        $body = $request->getBody();
+        $actual = $body->getContents();
+
+        $this->assertNotFalse(strpos($actual, 'name="foo"'));
+        $this->assertNotFalse(strpos($actual, 'bar'));
+        $this->assertInstanceOf(MultipartStream::class, $body);
+        $this->assertSame('multipart/form-data; boundary='.$body->getBoundary(), $request->getHeaderLine('Content-Type'));
+    }
+
+    /**
+     * @group RequestLocation
+     */
+    public function testVisitsLocationDoesNotOverwriteContentTypeHeader()
+    {
+        $location = new MultiPartLocation();
+        $command = new Command('foo', ['foo' => 'bar']);
+        $request = new Request('POST', 'http://httbin.org', ['Content-Type' => 'application/vnd.example']);
+        $param = new Parameter(['name' => 'foo']);
+        $request = $location->visit($command, $request, $param);
+        $operation = new Operation();
+        $request = $location->after($command, $request, $operation);
         $actual = $request->getBody()->getContents();
 
         $this->assertNotFalse(strpos($actual, 'name="foo"'));
         $this->assertNotFalse(strpos($actual, 'bar'));
+        $this->assertSame('application/vnd.example', $request->getHeaderLine('Content-Type'));
     }
 }


### PR DESCRIPTION
Fix multipart request serialization so the generated multipart Content-Type header is applied to the immutable PSR-7 request.

Preserve caller-provided Content-Type headers instead of overwriting them.

Supersedes #194.