### PR TITLE
Fix recursive parameter model inheritance

### DIFF
--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -12,6 +12,9 @@ class Parameter implements ToArrayInterface
 {
     private $originalData;
 
+    /** @var array */
+    private $resolvedData;
+
     /** @var string|null */
     private $name;
 
@@ -189,7 +192,7 @@ class Parameter implements ToArrayInterface
             if (isset($data['$ref'])) {
                 if ($model = $this->serviceDescription->getModel($data['$ref'])) {
                     $name = isset($data['name']) ? $data['name'] : null;
-                    $data = $model->toArray() + $data;
+                    $data = $model->toResolvedArray() + $data;
                     if ($name) {
                         $data['name'] = $name;
                     }
@@ -199,10 +202,12 @@ class Parameter implements ToArrayInterface
                 // with the actual data union in the parent's data (e.g. actual
                 // supersedes parent)
                 if ($extends = $this->serviceDescription->getModel($data['extends'])) {
-                    $data += $extends->toArray();
+                    $data += $extends->toResolvedArray();
                 }
             }
         }
+
+        $this->resolvedData = $data;
 
         // Pull configuration data into the parameter
         foreach ($data as $key => $value) {
@@ -229,6 +234,16 @@ class Parameter implements ToArrayInterface
     public function toArray()
     {
         return $this->originalData;
+    }
+
+    /**
+     * Convert the object to its internally resolved array
+     *
+     * @return array
+     */
+    private function toResolvedArray()
+    {
+        return $this->resolvedData;
     }
 
     /**

--- a/tests/ParameterTest.php
+++ b/tests/ParameterTest.php
@@ -251,6 +251,68 @@ class ParameterTest extends TestCase
         ], $p->toArray());
     }
 
+    public function testResolvesNestedExtendsUsingResolvedParentData()
+    {
+        $description = new Description([
+            'models' => [
+                'Grandparent' => [
+                    'type' => 'string',
+                    'location' => 'query',
+                    'default' => 'grandparent',
+                ],
+                'Parent' => [
+                    'extends' => 'Grandparent',
+                    'required' => true,
+                    'default' => 'parent',
+                ],
+                'Child' => [
+                    'extends' => 'Parent',
+                    'sentAs' => 'child_name',
+                ],
+            ],
+        ]);
+
+        $p = new Parameter(['extends' => 'Child', 'description' => 'actual'], ['description' => $description]);
+
+        $this->assertEquals('string', $p->getType());
+        $this->assertEquals('query', $p->getLocation());
+        $this->assertTrue($p->isRequired());
+        $this->assertEquals('parent', $p->getDefault());
+        $this->assertEquals('child_name', $p->getSentAs());
+        $this->assertEquals([
+            'extends' => 'Child',
+            'description' => 'actual',
+        ], $p->toArray());
+    }
+
+    public function testResolvesRefToModelThatExtendsAnotherModel()
+    {
+        $description = new Description([
+            'models' => [
+                'Base' => [
+                    'type' => 'string',
+                    'location' => 'query',
+                ],
+                'Derived' => [
+                    'extends' => 'Base',
+                    'default' => 'value',
+                    'name' => 'model_name',
+                ],
+            ],
+        ]);
+
+        $p = new Parameter(['$ref' => 'Derived', 'name' => 'input_name'], ['description' => $description]);
+
+        $this->assertEquals('input_name', $p->getName());
+        $this->assertEquals('string', $p->getType());
+        $this->assertEquals('query', $p->getLocation());
+        $this->assertEquals('value', $p->getDefault());
+        $this->assertEquals([
+            '$ref' => 'Derived',
+            'name' => 'input_name',
+        ], $p->toArray());
+    }
+
     public function testHasKeyMethod()
     {
         $p = new Parameter(['name' => 'foo', 'sentAs' => 'bar']);


### PR DESCRIPTION
- Preserve public Parameter::toArray() behavior while keeping internally resolved parameter data.
- Use resolved model data for internal $ref and extends expansion so recursive model inheritance sees ancestor data.
- Add regression tests for nested extends and $ref to an extended model.

---

Fixes #184.
Supersedes #185.
