### PR TITLE
[2.0] Default operation HTTP method to GET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Remove the legacy `responseClass` operation option; use `responseModel` instead
 * Drop support for PHP 7.2 and 7.3
 * Require `guzzlehttp/command` ^2.0, `guzzlehttp/guzzle` ^8.0, `guzzlehttp/psr7` ^3.0, and `guzzlehttp/uri-template` ^2.0
+* Default operations without an `httpMethod` to `GET` and reject invalid `httpMethod` values
 
 ## 1.6.0 - UPCOMING
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -59,6 +59,30 @@ $description = new Description([
 In 2.0, `baseUrl` and `responseClass` are retained only as extra description or
 operation data. They no longer configure request base URIs or response models.
 
+#### Operation HTTP Methods
+
+Operations without an `httpMethod` now default to `GET` in
+`GuzzleHttp\Command\Guzzle\Operation`, matching the request method already used
+by the serializer at runtime.
+
+This changes the public operation data returned by `getHttpMethod()` and
+`toArray()`:
+
+```php
+$operation = new Operation();
+
+// 1.x
+$operation->getHttpMethod(); // ''
+$operation->toArray()['httpMethod']; // ''
+
+// 2.0
+$operation->getHttpMethod(); // 'GET'
+$operation->toArray()['httpMethod']; // 'GET'
+```
+
+Explicit `httpMethod` values must now be non-empty strings. Passing an empty
+string or a non-string value throws `InvalidArgumentException`.
+
 #### Command Client Dependency
 
 `GuzzleHttp\Command\Guzzle\GuzzleClient` continues to build on

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -55,7 +55,7 @@ class Operation implements ToArrayInterface
     {
         static $defaults = [
             'name' => '',
-            'httpMethod' => '',
+            'httpMethod' => 'GET',
             'uri' => '',
             'responseModel' => null,
             'notes' => '',
@@ -72,6 +72,12 @@ class Operation implements ToArrayInterface
 
         if (isset($config['extends'])) {
             $config = $this->resolveExtends($config['extends'], $config);
+        }
+
+        if (array_key_exists('httpMethod', $config)
+            && (!is_string($config['httpMethod']) || $config['httpMethod'] === '')
+        ) {
+            throw new \InvalidArgumentException('httpMethod must be a non-empty string');
         }
 
         $this->config = $config + $defaults;
@@ -146,7 +152,7 @@ class Operation implements ToArrayInterface
     /**
      * Get the HTTP method of the operation
      *
-     * @return string|null
+     * @return string
      */
     public function getHttpMethod()
     {

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -124,6 +124,38 @@ class OperationTest extends TestCase
         $this->assertEquals(['foo' => 'baz', 'bar' => 123], $o->getData());
     }
 
+    public function testDefaultsHttpMethodToGet()
+    {
+        $o = new Operation();
+
+        $this->assertEquals('GET', $o->getHttpMethod());
+        $this->assertEquals('GET', $o->toArray()['httpMethod']);
+    }
+
+    public function testCanProvideAlternateHttpMethod()
+    {
+        $o = new Operation(['httpMethod' => 'POST']);
+
+        $this->assertEquals('POST', $o->getHttpMethod());
+        $this->assertEquals('POST', $o->toArray()['httpMethod']);
+    }
+
+    public function testEnsuresHttpMethodIsNotEmptyString()
+    {
+        $this->expectExceptionMessage('httpMethod must be a non-empty string');
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Operation(['httpMethod' => '']);
+    }
+
+    public function testEnsuresHttpMethodIsString()
+    {
+        $this->expectExceptionMessage('httpMethod must be a non-empty string');
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Operation(['httpMethod' => false]);
+    }
+
     public function testEnsuresParametersAreArrays()
     {
         $this->expectExceptionMessage('Parameters must be arrays');
@@ -197,6 +229,7 @@ class OperationTest extends TestCase
                 ],
                 'B' => [
                     'extends' => 'A',
+                    'httpMethod' => 'POST',
                     'summary' => 'Bar',
                 ],
                 'C' => [
@@ -210,17 +243,20 @@ class OperationTest extends TestCase
         ]);
 
         $a = $d->getOperation('A');
+        $this->assertEquals('GET', $a->getHttpMethod());
         $this->assertEquals('foo', $a->getSummary());
         $this->assertTrue($a->hasParam('A'));
         $this->assertEquals('string', $a->getParam('B')->getType());
 
         $b = $d->getOperation('B');
         $this->assertTrue($a->hasParam('A'));
+        $this->assertEquals('POST', $b->getHttpMethod());
         $this->assertEquals('Bar', $b->getSummary());
         $this->assertEquals('string', $a->getParam('B')->getType());
 
         $c = $d->getOperation('C');
         $this->assertTrue($a->hasParam('A'));
+        $this->assertEquals('POST', $c->getHttpMethod());
         $this->assertEquals('Bar', $c->getSummary());
         $this->assertEquals('number', $c->getParam('B')->getType());
     }


### PR DESCRIPTION
## Summary
- Default Operation httpMethod to GET.
- Reject explicitly empty or non-string httpMethod values.
- Add tests for defaulting, validation, and operation inheritance.

## Rationale
The serializer already falls back to GET when an operation has no HTTP method. This makes Operation::getHttpMethod() and Operation::toArray() reflect that effective runtime behavior.

## Breaking Change
This is targeted to 2.0 because:
- new Operation()->getHttpMethod() now returns GET instead of an empty string.
- new Operation()->toArray()['httpMethod'] now returns GET instead of an empty string.
- new Operation(['httpMethod' => '']) now throws InvalidArgumentException.

Supersedes #167.
Related to #166.