### PR TITLE
Handle malformed XML responses safely

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -115,12 +115,6 @@ parameters:
 			path: src/ResponseLocation/XmlLocation.php
 
 		-
-			message: '#^Property GuzzleHttp\\Command\\Guzzle\\ResponseLocation\\XmlLocation\:\:\$xml \(SimpleXMLElement\) does not accept null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/ResponseLocation/XmlLocation.php
-
-		-
 			message: '#^Variable \$result in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 1

--- a/src/ResponseLocation/XmlLocation.php
+++ b/src/ResponseLocation/XmlLocation.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 class XmlLocation extends AbstractLocation
 {
-    /** @var \SimpleXMLElement XML document being visited */
+    /** @var \SimpleXMLElement|null XML document being visited */
     private $xml;
 
     /**
@@ -33,7 +33,23 @@ class XmlLocation extends AbstractLocation
         ResponseInterface $response,
         Parameter $model
     ) {
-        $this->xml = simplexml_load_string((string) $response->getBody());
+        $this->xml = null;
+
+        $previous = libxml_use_internal_errors(true);
+        libxml_clear_errors();
+
+        try {
+            $xml = simplexml_load_string((string) $response->getBody());
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
+
+        if (!$xml instanceof \SimpleXMLElement) {
+            throw new \RuntimeException('Unable to parse XML response');
+        }
+
+        $this->xml = $xml;
 
         return $result;
     }
@@ -53,7 +69,7 @@ class XmlLocation extends AbstractLocation
         ) {
             $result = new Result(array_merge(
                 $result->toArray(),
-                self::xmlToArray($this->xml)
+                self::xmlToArray($this->getXml())
             ));
         }
 
@@ -76,15 +92,30 @@ class XmlLocation extends AbstractLocation
             list($ns, $sentAs) = explode(':', $sentAs);
         }
 
+        $xml = $this->getXml();
+        $children = $xml->children($ns, true)->{$sentAs};
+
         // Process the primary property
-        if (count($this->xml->children($ns, true)->{$sentAs})) {
+        if (count($children)) {
             $result[$param->getName()] = $this->recursiveProcess(
                 $param,
-                $this->xml->children($ns, true)->{$sentAs}
+                $children
             );
         }
 
         return $result;
+    }
+
+    /**
+     * @return \SimpleXMLElement
+     */
+    private function getXml()
+    {
+        if (!$this->xml instanceof \SimpleXMLElement) {
+            throw new \RuntimeException('XML response has not been parsed');
+        }
+
+        return $this->xml;
     }
 
     /**

--- a/tests/ResponseLocation/XmlLocationTest.php
+++ b/tests/ResponseLocation/XmlLocationTest.php
@@ -53,6 +53,63 @@ class XmlLocationTest extends TestCase
     /**
      * @group ResponseLocation
      */
+    public function testRejectsMalformedXmlResponses()
+    {
+        $location = new XmlLocation();
+        $model = new Parameter();
+        $response = new Response(200, [], Psr7\Utils::streamFor('<w><vim>bar</w>'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to parse XML response');
+
+        $location->before(new Result(), $response, $model);
+    }
+
+    /**
+     * @group ResponseLocation
+     */
+    public function testMalformedXmlClearsPreviousParsedResponse()
+    {
+        $location = new XmlLocation();
+        $model = new Parameter();
+        $validResponse = new Response(200, [], Psr7\Utils::streamFor('<w><vim>bar</vim></w>'));
+        $malformedResponse = new Response(200, [], Psr7\Utils::streamFor('<w><vim>bar</w>'));
+
+        $location->before(new Result(), $validResponse, $model);
+
+        try {
+            $location->before(new Result(), $malformedResponse, $model);
+            $this->fail('Expected malformed XML response to be rejected.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Unable to parse XML response', $e->getMessage());
+        }
+
+        $parameter = new Parameter(['name' => 'val', 'sentAs' => 'vim']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('XML response has not been parsed');
+
+        $location->visit(new Result(), $validResponse, $parameter);
+    }
+
+    /**
+     * @group ResponseLocation
+     */
+    public function testVisitRequiresParsedXmlResponse()
+    {
+        $location = new XmlLocation();
+        $parameter = new Parameter(['name' => 'val', 'sentAs' => 'vim']);
+        $response = new Response(200, [], Psr7\Utils::streamFor('<w><vim>bar</vim></w>'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('XML response has not been parsed');
+
+        $location->visit(new Result(), $response, $parameter);
+    }
+
+    /**
+     * @group ResponseLocation
+     */
     public function testEnsuresFlatArraysAreFlat()
     {
         $param = new Parameter([


### PR DESCRIPTION
## Summary
- Suppress and clear libxml parser errors while parsing XML responses.
- Throw a clear RuntimeException when XML responses cannot be parsed.
- Guard XML visitor access so failed parsing cannot later trigger Error or TypeError.

## Rationale
simplexml_load_string() returns false for malformed XML. The XML response visitor currently stores that unchecked value and later treats it as a SimpleXMLElement.

Malformed XML is invalid response data, so failing deterministically is safer than emitting warnings and crashing later.