### PR TITLE
[1.5] Use current service description keys in tests

### DIFF
--- a/tests/DescriptionTest.php
+++ b/tests/DescriptionTest.php
@@ -56,7 +56,7 @@ class DescriptionTest extends TestCase
         $this->assertEquals(['Tag', 'Person'], array_keys($d->getModels()));
     }
 
-    public function testCanUseResponseClass()
+    public function testCanUseLegacyResponseClass()
     {
         $d = new Description([
             'operations' => [
@@ -65,7 +65,7 @@ class DescriptionTest extends TestCase
             'models' => ['Tag' => ['type' => 'object']],
         ]);
         $op = $d->getOperation('foo');
-        $this->assertNotNull($op->getResponseModel());
+        $this->assertSame('Tag', $op->getResponseModel());
     }
 
     public function testRetrievingMissingModelThrowsException()
@@ -121,7 +121,7 @@ class DescriptionTest extends TestCase
         ]);
     }
 
-    public function testHasbaseUrl()
+    public function testCanUseLegacyBaseUrl()
     {
         $description = new Description(['baseUrl' => 'http://foo.com']);
         $this->assertEquals('http://foo.com', $description->getBaseUri());

--- a/tests/DeserializerTest.php
+++ b/tests/DeserializerTest.php
@@ -97,7 +97,7 @@ class DeserializerTest extends TestCase
                 'foo' => [
                     'uri' => '/{foo}',
                     'httpMethod' => 'GET',
-                    'responseClass' => 'Foo',
+                    'responseModel' => 'Foo',
                     'parameters' => [
                         'bar' => [
                             'type' => 'string',
@@ -138,7 +138,7 @@ class DeserializerTest extends TestCase
                 'foo' => [
                     'uri' => '/{foo}',
                     'httpMethod' => 'GET',
-                    'responseClass' => 'Foo',
+                    'responseModel' => 'Foo',
                     'parameters' => [
                         'bar' => [
                             'type' => 'string',
@@ -180,7 +180,7 @@ class DeserializerTest extends TestCase
                 'foo' => [
                     'uri' => '/{foo}',
                     'httpMethod' => 'GET',
-                    'responseClass' => 'Foo',
+                    'responseModel' => 'Foo',
                     'parameters' => [
                         'bar' => [
                             'type' => 'string',
@@ -222,7 +222,7 @@ class DeserializerTest extends TestCase
                 'foo' => [
                     'uri' => '/{foo}',
                     'httpMethod' => 'GET',
-                    'responseClass' => 'Foo',
+                    'responseModel' => 'Foo',
                     'parameters' => [
                         'bar' => [
                             'type' => 'string',
@@ -316,7 +316,7 @@ class DeserializerTest extends TestCase
                 'Login' => [
                     'uri' => '/{foo}',
                     'httpMethod' => 'POST',
-                    'responseClass' => 'LoginResponse',
+                    'responseModel' => 'LoginResponse',
                     'parameters' => [
                         'username' => [
                             'type' => 'string',

--- a/tests/GuzzleClientTest.php
+++ b/tests/GuzzleClientTest.php
@@ -981,7 +981,7 @@ class GuzzleClientTest extends TestCase
     {
         $client = new HttpClient();
         $description = new Description([
-            'baseUrl' => Server::$url,
+            'baseUri' => Server::$url,
             'operations' => [
                 'testing' => [
                     'httpMethod' => 'GET',
@@ -1028,7 +1028,7 @@ class GuzzleClientTest extends TestCase
     {
         $client = new HttpClient();
         $description = new Description([
-            'baseUrl' => Server::$url,
+            'baseUri' => Server::$url,
             'operations' => [
                 'testing' => [
                     'httpMethod' => 'GET',


### PR DESCRIPTION
## Summary
- Update normal deserializer test fixtures to use `responseModel` instead of legacy `responseClass`.
- Update normal client test fixtures to use `baseUri` instead of legacy `baseUrl`.
- Keep explicit 1.x compatibility coverage for `responseClass` and `baseUrl`.

## Rationale
This removes incidental test reliance on legacy service description aliases before removing those aliases from 2.0.