### PR TITLE
[1.6] Deprecate legacy service description aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.6.0 - UPCOMING
+
+* Deprecate the legacy `baseUrl` service description option; use `baseUri` instead
+* Deprecate the legacy `responseClass` operation option; use `responseModel` instead
+
 ## 1.5.0 - 2026-05-18
 
 * Add PHP 8.5 support

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "guzzlehttp/command": "^1.4",
         "guzzlehttp/guzzle": "^7.10",
         "guzzlehttp/psr7": "^2.8",
-        "guzzlehttp/uri-template": "^1.0.5"
+        "guzzlehttp/uri-template": "^1.0.5",
+        "symfony/deprecation-contracts": "^2.5 || ^3.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",

--- a/src/Description.php
+++ b/src/Description.php
@@ -56,6 +56,12 @@ class Description implements DescriptionInterface
         // Set the baseUri
         // Account for the old style of using baseUrl
         if (isset($config['baseUrl'])) {
+            trigger_deprecation(
+                'guzzlehttp/guzzle-services',
+                '1.6',
+                'The "baseUrl" service description option is deprecated, use "baseUri" instead.'
+            );
+
             $config['baseUri'] = $config['baseUrl'];
         }
         $this->baseUri = isset($config['baseUri']) ? new Uri($config['baseUri']) : new Uri();

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -78,6 +78,12 @@ class Operation implements ToArrayInterface
 
         // Account for the old style of using responseClass
         if (isset($config['responseClass'])) {
+            trigger_deprecation(
+                'guzzlehttp/guzzle-services',
+                '1.6',
+                'The "responseClass" operation option is deprecated, use "responseModel" instead.'
+            );
+
             $this->config['responseModel'] = $config['responseClass'];
         }
 

--- a/tests/DescriptionTest.php
+++ b/tests/DescriptionTest.php
@@ -64,7 +64,6 @@ class DescriptionTest extends TestCase
             ],
             'models' => ['Tag' => ['type' => 'object']],
         ]);
-
         $op = $d->getOperation('foo');
         $this->assertSame('Tag', $op->getResponseModel());
     }

--- a/tests/DescriptionTest.php
+++ b/tests/DescriptionTest.php
@@ -64,6 +64,7 @@ class DescriptionTest extends TestCase
             ],
             'models' => ['Tag' => ['type' => 'object']],
         ]);
+
         $op = $d->getOperation('foo');
         $this->assertSame('Tag', $op->getResponseModel());
     }


### PR DESCRIPTION
## Summary
- Add `symfony/deprecation-contracts` as a runtime dependency.
- Trigger deprecation notices when using legacy `baseUrl` instead of `baseUri`.
- Trigger deprecation notices when using legacy `responseClass` instead of `responseModel`.

## Rationale
These aliases remain supported in 1.x, but warning users in 1.6 prepares for removing the aliases in 2.0.