### PR TITLE
[2.0] Remove legacy service description aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2.0.0 - UPCOMING
+
+* Remove the legacy `baseUrl` service description option; use `baseUri` instead
+* Remove the legacy `responseClass` operation option; use `responseModel` instead
+
 ## 1.6.0 - UPCOMING
 
 * Deprecate the legacy `baseUrl` service description option; use `baseUri` instead

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
         "guzzlehttp/command": "^1.4",
         "guzzlehttp/guzzle": "^7.10",
         "guzzlehttp/psr7": "^2.8",
-        "guzzlehttp/uri-template": "^1.0.5",
-        "symfony/deprecation-contracts": "^2.5 || ^3.0"
+        "guzzlehttp/uri-template": "^1.0.5"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",

--- a/src/Description.php
+++ b/src/Description.php
@@ -54,16 +54,6 @@ class Description implements DescriptionInterface
         }
 
         // Set the baseUri
-        // Account for the old style of using baseUrl
-        if (isset($config['baseUrl'])) {
-            trigger_deprecation(
-                'guzzlehttp/guzzle-services',
-                '1.6',
-                'The "baseUrl" service description option is deprecated, use "baseUri" instead.'
-            );
-
-            $config['baseUri'] = $config['baseUrl'];
-        }
         $this->baseUri = isset($config['baseUri']) ? new Uri($config['baseUri']) : new Uri();
 
         // Ensure that the models and operations properties are always arrays

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -76,17 +76,6 @@ class Operation implements ToArrayInterface
 
         $this->config = $config + $defaults;
 
-        // Account for the old style of using responseClass
-        if (isset($config['responseClass'])) {
-            trigger_deprecation(
-                'guzzlehttp/guzzle-services',
-                '1.6',
-                'The "responseClass" operation option is deprecated, use "responseModel" instead.'
-            );
-
-            $this->config['responseModel'] = $config['responseClass'];
-        }
-
         $this->resolveParameters();
     }
 

--- a/tests/DescriptionTest.php
+++ b/tests/DescriptionTest.php
@@ -56,7 +56,7 @@ class DescriptionTest extends TestCase
         $this->assertEquals(['Tag', 'Person'], array_keys($d->getModels()));
     }
 
-    public function testCanUseLegacyResponseClass()
+    public function testDoesNotUseLegacyResponseClass()
     {
         $d = new Description([
             'operations' => [
@@ -65,7 +65,8 @@ class DescriptionTest extends TestCase
             'models' => ['Tag' => ['type' => 'object']],
         ]);
         $op = $d->getOperation('foo');
-        $this->assertSame('Tag', $op->getResponseModel());
+        $this->assertNull($op->getResponseModel());
+        $this->assertSame('Tag', $op->toArray()['responseClass']);
     }
 
     public function testRetrievingMissingModelThrowsException()
@@ -121,10 +122,11 @@ class DescriptionTest extends TestCase
         ]);
     }
 
-    public function testCanUseLegacyBaseUrl()
+    public function testDoesNotUseLegacyBaseUrl()
     {
         $description = new Description(['baseUrl' => 'http://foo.com']);
-        $this->assertEquals('http://foo.com', $description->getBaseUri());
+        $this->assertEquals('', $description->getBaseUri());
+        $this->assertSame('http://foo.com', $description->getData('baseUrl'));
     }
 
     public function testHasbaseUri()


### PR DESCRIPTION
## Summary
- Remove the legacy `baseUrl` alias for `baseUri`.
- Remove the legacy `responseClass` alias for `responseModel`.
- Remove the direct `symfony/deprecation-contracts` dependency added for 1.6 deprecation notices.
- Add 2.0 changelog notes for the removals.

## Breaking Change
- `baseUrl` no longer sets the service description base URI; use `baseUri`.
- `responseClass` no longer sets the operation response model; use `responseModel`.