### PR TITLE
[2.0] Prepare 2.0 dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.2'
+          php-version: '7.4'
           ini-values: error_reporting=E_ALL
           coverage: 'none'
           extensions: mbstring
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Set up PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Remove the legacy `baseUrl` service description option; use `baseUri` instead
 * Remove the legacy `responseClass` operation option; use `responseModel` instead
+* Drop support for PHP 7.2 and 7.3
+* Require `guzzlehttp/command` ^2.0, `guzzlehttp/guzzle` ^8.0, `guzzlehttp/psr7` ^3.0, and `guzzlehttp/uri-template` ^2.0
 
 ## 1.6.0 - UPCOMING
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ This project can be installed using Composer:
 
 ``composer require guzzlehttp/guzzle-services``
 
+## Version Guidance
+
+| Version | Status              | PHP Version  |
+|---------|---------------------|--------------|
+| 1.x     | Latest              | >=7.2.5,<8.6 |
+| 2.x     | Experimental        | >=7.4,<8.6   |
+
+See [UPGRADING.md](UPGRADING.md) for notes on upgrading to 2.0.
+
 For **Guzzle 5**, use ``composer require guzzlehttp/guzzle-services:0.6``.
 
 **Note:** If Composer is not installed [globally](https://getcomposer.org/doc/00-intro.md#globally) then you may need to run the preceding Composer commands using ``php composer.phar`` (where ``composer.phar`` is the path to your copy of Composer), instead of just ``composer``.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,81 @@
+Guzzle Services Upgrade Guide
+=============================
+
+1.x to 2.0
+----------
+
+#### PHP Version and Dependencies
+
+Guzzle Services 2.0 requires PHP `^7.4 || ^8.0`. Guzzle Services 1.x supported
+PHP `^7.2.5 || ^8.0`.
+
+Guzzle Services 2.0 also requires Guzzle Command 2.x, Guzzle 8.x, Guzzle PSR-7
+3.x, and Guzzle URI Template 2.x.
+
+If your application still supports PHP 7.2 or 7.3, or still uses the Guzzle 7
+dependency stack, continue using Guzzle Services 1.x until your minimum PHP and
+dependency versions are raised.
+
+#### Legacy Service Description Aliases
+
+The legacy `baseUrl` service description option has been removed. Use `baseUri`
+instead.
+
+```php
+// 1.x, no longer handled in 2.0
+$description = new Description([
+    'baseUrl' => 'https://api.example.com',
+]);
+
+// 2.0
+$description = new Description([
+    'baseUri' => 'https://api.example.com',
+]);
+```
+
+The legacy `responseClass` operation option has also been removed. Use
+`responseModel` instead.
+
+```php
+// 1.x, no longer handled in 2.0
+$description = new Description([
+    'operations' => [
+        'GetUser' => [
+            'responseClass' => 'User',
+        ],
+    ],
+]);
+
+// 2.0
+$description = new Description([
+    'operations' => [
+        'GetUser' => [
+            'responseModel' => 'User',
+        ],
+    ],
+]);
+```
+
+In 2.0, `baseUrl` and `responseClass` are retained only as extra description or
+operation data. They no longer configure request base URIs or response models.
+
+#### Command Client Dependency
+
+`GuzzleHttp\Command\Guzzle\GuzzleClient` continues to build on
+`guzzlehttp/command`, but the required Command major version is now 2.x. Review
+the Guzzle Command 2.0 upgrade guide if your application uses Command APIs
+directly.
+
+#### Service Descriptions and URIs
+
+Guzzle PSR-7 3.x validates URI hosts, URI schemes, query values, and
+iterator-backed stream chunks more strictly. Invalid `baseUri` values, operation
+URI templates, request hosts, or unsupported query data may now fail earlier.
+
+Guzzle URI Template 2.x drops PHP 7.2 and 7.3 support. URI template expansion is
+otherwise expected to remain compatible with 1.x.
+
+#### Downstream Upgrade Guides
+
+Review the Guzzle 8, Guzzle Command 2.0, Guzzle PSR-7 3.0, Guzzle Promises 3.0,
+and Guzzle URI Template 2.0 upgrade guides for dependency-level behavior changes.

--- a/composer.json
+++ b/composer.json
@@ -25,15 +25,16 @@
         }
     ],
     "require": {
-        "php": "^7.2.5 || ^8.0",
-        "guzzlehttp/command": "^1.4",
-        "guzzlehttp/guzzle": "^7.10",
-        "guzzlehttp/psr7": "^2.8",
-        "guzzlehttp/uri-template": "^1.0.5"
+        "php": "^7.4 || ^8.0",
+        "guzzlehttp/command": "^2.0@dev",
+        "guzzlehttp/guzzle": "^8.0@dev",
+        "guzzlehttp/psr7": "^3.0@dev",
+        "guzzlehttp/uri-template": "^2.0@dev"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",
-        "guzzlehttp/test-server": "^0.3.2",
+        "guzzlehttp/promises": "^3.0@dev",
+        "guzzlehttp/test-server": "^1.0@dev",
         "phpunit/phpunit": "^8.5.52 || ^9.6.34"
     },
     "suggest": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -109,12 +109,6 @@ parameters:
 			path: src/ResponseLocation/XmlLocation.php
 
 		-
-			message: '#^Parameter \#1 \$namespaceOrPrefix of method SimpleXMLElement\:\:attributes\(\) expects string, null given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/ResponseLocation/XmlLocation.php
-
-		-
 			message: '#^Variable \$result in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 1
@@ -125,12 +119,6 @@ parameters:
 			identifier: deadCode.unreachable
 			count: 1
 			path: src/SchemaFormatter.php
-
-		-
-			message: '#^Parameter \#1 \$array_arg of function sort contains unresolvable type\.$#'
-			identifier: argument.unresolvableType
-			count: 1
-			path: src/SchemaValidator.php
 
 		-
 			message: '#^Strict comparison using \=\=\= between null and string will always evaluate to false\.$#'

--- a/src/ResponseLocation/XmlLocation.php
+++ b/src/ResponseLocation/XmlLocation.php
@@ -268,8 +268,8 @@ class XmlLocation extends AbstractLocation
     /**
      * Convert an XML document to an array.
      *
-     * @param int  $nesting
-     * @param null $ns
+     * @param string|null $ns
+     * @param int         $nesting
      *
      * @return array
      */
@@ -282,7 +282,9 @@ class XmlLocation extends AbstractLocation
         $children = $xml->children($ns, true);
 
         foreach ($children as $name => $child) {
-            $attributes = (array) $child->attributes($ns, true);
+            $attributes = $ns === null
+                ? (array) $child->attributes()
+                : (array) $child->attributes($ns, true);
             if (!isset($result[$name])) {
                 $childArray = self::xmlToArray($child, $ns, $nesting + 1);
                 $result[$name] = $attributes
@@ -315,7 +317,9 @@ class XmlLocation extends AbstractLocation
         }
 
         // Process attributes
-        $attributes = (array) $xml->attributes($ns, true);
+        $attributes = $ns === null
+            ? (array) $xml->attributes()
+            : (array) $xml->attributes($ns, true);
         if ($attributes) {
             if ($text !== null) {
                 $result['value'] = $text;

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -17,8 +17,8 @@ class SchemaValidator
      */
     protected $castIntegerToStringType;
 
-    /** @var array Errors encountered while validating */
-    protected $errors;
+    /** @var string[] Errors encountered while validating */
+    protected array $errors = [];
 
     /**
      * @param bool $castIntegerToStringType Set to true to convert integers
@@ -41,7 +41,9 @@ class SchemaValidator
         if (empty($this->errors)) {
             return true;
         }
-        sort($this->errors);
+        $errors = $this->getErrors();
+        sort($errors);
+        $this->errors = $errors;
 
         return false;
     }
@@ -49,7 +51,7 @@ class SchemaValidator
     /**
      * Get the errors encountered while validating
      *
-     * @return array
+     * @return string[]
      */
     public function getErrors()
     {


### PR DESCRIPTION
This prepares the 2.0 branch for the next Guzzle stack by dropping PHP 7.2 and 7.3 and requiring Command 2, Guzzle 8, PSR-7 3, and URI Template 2. It also adds version guidance, an upgrade guide, and small compatibility updates for the Guzzle 8 dependency stack.