### PR TITLE
Replace deprecated JSON helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.5.1 - Upcoming
+
+* Replace deprecated Guzzle JSON helper functions
+
 ## 1.5.0 - 2026-05-18
 
 * Add PHP 8.5 support

--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -5,6 +5,7 @@ namespace GuzzleHttp\Command\Guzzle\ResponseLocation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Result;
 use GuzzleHttp\Command\ResultInterface;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -35,7 +36,7 @@ class JsonLocation extends AbstractLocation
     ) {
         $body = (string) $response->getBody();
         $body = $body ?: '{}';
-        $this->json = \GuzzleHttp\json_decode($body, true);
+        $this->json = Utils::jsonDecode($body, true);
         // relocate named arrays, so that they have the same structure as
         //  arrays nested in objects and visit can work on them in the same way
         if ($model->getType() === 'array' && ($name = $model->getName())) {

--- a/tests/GuzzleClientTest.php
+++ b/tests/GuzzleClientTest.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Server\Server;
+use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -778,7 +779,7 @@ class GuzzleClientTest extends TestCase
     private function responseToResultTransformer()
     {
         return function (ResponseInterface $response, RequestInterface $request, CommandInterface $command) {
-            $data = \GuzzleHttp\json_decode($response->getBody(), true);
+            $data = Utils::jsonDecode($response->getBody(), true);
             parse_str($request->getBody(), $data['_request']);
 
             return new Result($data);

--- a/tests/ResponseLocation/JsonLocationTest.php
+++ b/tests/ResponseLocation/JsonLocationTest.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Command\Result;
 use GuzzleHttp\Command\ResultInterface;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -43,7 +44,7 @@ class JsonLocationTest extends TestCase
     public function testVisitsWiredArray()
     {
         $json = ['car_models' => ['ferrari', 'aston martin']];
-        $body = \GuzzleHttp\json_encode($json);
+        $body = Utils::jsonEncode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -132,7 +133,7 @@ class JsonLocationTest extends TestCase
             ['foo' => 'bar'],
             ['baz' => 'bam'],
         ];
-        $body = \GuzzleHttp\json_encode($json);
+        $body = Utils::jsonEncode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -179,7 +180,7 @@ class JsonLocationTest extends TestCase
                 'baz',
             ],
         ];
-        $body = \GuzzleHttp\json_encode($json);
+        $body = Utils::jsonEncode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -320,7 +321,7 @@ class JsonLocationTest extends TestCase
             ],
             'baz' => 'boo',
         ];
-        $body = \GuzzleHttp\json_encode($json);
+        $body = Utils::jsonEncode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -355,7 +356,7 @@ class JsonLocationTest extends TestCase
             ],
         ];
 
-        $body = \GuzzleHttp\json_encode($json);
+        $body = Utils::jsonEncode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -429,7 +430,7 @@ class JsonLocationTest extends TestCase
             ],
         ];
 
-        $body = \GuzzleHttp\json_encode($json);
+        $body = Utils::jsonEncode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -511,7 +512,7 @@ class JsonLocationTest extends TestCase
     {
         $json = json_decode('{"scalar":"foo","nested":[{"bar":123,"baz":false},{"bar":345,"baz":true},{"bar":678,"baz":true}]}');
 
-        $body = \GuzzleHttp\json_encode($json);
+        $body = Utils::jsonEncode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 


### PR DESCRIPTION
This replaces deprecated Guzzle JSON helper function calls with the Utils methods on the 1.5 branch and adds a 1.5.1 changelog entry.