### PR TITLE
[1.6] Fix xmlToArray PHPDoc

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -109,12 +109,6 @@ parameters:
 			path: src/ResponseLocation/XmlLocation.php
 
 		-
-			message: '#^Parameter \#1 \$namespaceOrPrefix of method SimpleXMLElement\:\:attributes\(\) expects string, null given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/ResponseLocation/XmlLocation.php
-
-		-
 			message: '#^Variable \$result in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 1

--- a/src/ResponseLocation/XmlLocation.php
+++ b/src/ResponseLocation/XmlLocation.php
@@ -268,8 +268,8 @@ class XmlLocation extends AbstractLocation
     /**
      * Convert an XML document to an array.
      *
-     * @param int  $nesting
-     * @param null $ns
+     * @param string|null $ns
+     * @param int         $nesting
      *
      * @return array
      */


### PR DESCRIPTION
This corrects the xmlToArray PHPDoc on the 1.6 branch and removes the stale PHPStan baseline entry.