### PR TITLE
Serialize header location scalar values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.5.1 - Upcoming
 
 * Replace deprecated Guzzle JSON helper functions
-* Serialize scalar header location values before passing them to PSR-7
+* Serialize scalar header location values and reject invalid header location values before passing them to PSR-7
 
 ## 1.5.0 - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.5.1 - Upcoming
 
 * Replace deprecated Guzzle JSON helper functions
+* Serialize scalar header location values before passing them to PSR-7
 
 ## 1.5.0 - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.5.1 - Upcoming
 
 * Replace deprecated Guzzle JSON helper functions
-* Serialize scalar header location values and reject invalid header location values before passing them to PSR-7
+* Serialize and validate header location values
 
 ## 1.5.0 - 2026-05-18
 

--- a/src/RequestLocation/HeaderLocation.php
+++ b/src/RequestLocation/HeaderLocation.php
@@ -60,7 +60,7 @@ class HeaderLocation extends AbstractLocation
     /**
      * @param mixed $value
      *
-     * @return mixed
+     * @return string|string[]
      */
     private static function prepareHeaderValue($value)
     {
@@ -71,7 +71,7 @@ class HeaderLocation extends AbstractLocation
         if (is_array($value)) {
             foreach ($value as $key => $item) {
                 if (!is_scalar($item)) {
-                    throw self::invalidHeaderValue();
+                    throw new \InvalidArgumentException('Header location values must be scalar or an array of scalars.');
                 }
 
                 $value[$key] = (string) $item;
@@ -80,11 +80,6 @@ class HeaderLocation extends AbstractLocation
             return $value;
         }
 
-        throw self::invalidHeaderValue();
-    }
-
-    private static function invalidHeaderValue(): \InvalidArgumentException
-    {
-        return new \InvalidArgumentException('Header location values must be scalar or an array of scalars.');
+        throw new \InvalidArgumentException('Header location values must be scalar or an array of scalars.');
     }
 }

--- a/src/RequestLocation/HeaderLocation.php
+++ b/src/RequestLocation/HeaderLocation.php
@@ -70,12 +70,21 @@ class HeaderLocation extends AbstractLocation
 
         if (is_array($value)) {
             foreach ($value as $key => $item) {
-                if (is_scalar($item)) {
-                    $value[$key] = (string) $item;
+                if (!is_scalar($item)) {
+                    throw self::invalidHeaderValue();
                 }
+
+                $value[$key] = (string) $item;
             }
+
+            return $value;
         }
 
-        return $value;
+        throw self::invalidHeaderValue();
+    }
+
+    private static function invalidHeaderValue(): \InvalidArgumentException
+    {
+        return new \InvalidArgumentException('Header location values must be scalar or an array of scalars.');
     }
 }

--- a/src/RequestLocation/HeaderLocation.php
+++ b/src/RequestLocation/HeaderLocation.php
@@ -33,7 +33,7 @@ class HeaderLocation extends AbstractLocation
     ) {
         $value = $command[$param->getName()];
 
-        return $request->withHeader($param->getWireName(), $param->filter($value));
+        return $request->withHeader($param->getWireName(), self::prepareHeaderValue($param->filter($value)));
     }
 
     /**
@@ -49,11 +49,33 @@ class HeaderLocation extends AbstractLocation
         if ($additional && ($additional->getLocation() === $this->locationName)) {
             foreach ($command->toArray() as $key => $value) {
                 if (!$operation->hasParam($key)) {
-                    $request = $request->withHeader($key, $additional->filter($value));
+                    $request = $request->withHeader($key, self::prepareHeaderValue($additional->filter($value)));
                 }
             }
         }
 
         return $request;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    private static function prepareHeaderValue($value)
+    {
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $key => $item) {
+                if (is_scalar($item)) {
+                    $value[$key] = (string) $item;
+                }
+            }
+        }
+
+        return $value;
     }
 }

--- a/tests/RequestLocation/HeaderLocationTest.php
+++ b/tests/RequestLocation/HeaderLocationTest.php
@@ -34,6 +34,51 @@ class HeaderLocationTest extends TestCase
     /**
      * @group RequestLocation
      */
+    public function testVisitsLocationSerializesScalarHeaderValues()
+    {
+        $location = new HeaderLocation('header');
+        $param = new Parameter(['name' => 'foo']);
+
+        $request = $location->visit(
+            new Command('foo', ['foo' => 123]),
+            new Request('POST', 'http://httbin.org'),
+            $param
+        );
+        $this->assertEquals([0 => '123'], $request->getHeader('foo'));
+
+        $request = $location->visit(
+            new Command('foo', ['foo' => true]),
+            new Request('POST', 'http://httbin.org'),
+            $param
+        );
+        $this->assertEquals([0 => '1'], $request->getHeader('foo'));
+
+        $request = $location->visit(
+            new Command('foo', ['foo' => false]),
+            new Request('POST', 'http://httbin.org'),
+            $param
+        );
+        $this->assertEquals([0 => ''], $request->getHeader('foo'));
+    }
+
+    /**
+     * @group RequestLocation
+     */
+    public function testVisitsLocationSerializesArrayHeaderValues()
+    {
+        $location = new HeaderLocation('header');
+        $command = new Command('foo', ['foo' => ['bar', 123, true, false]]);
+        $request = new Request('POST', 'http://httbin.org');
+        $param = new Parameter(['name' => 'foo']);
+
+        $request = $location->visit($command, $request, $param);
+
+        $this->assertEquals([0 => 'bar', 1 => '123', 2 => '1', 3 => ''], $request->getHeader('foo'));
+    }
+
+    /**
+     * @group RequestLocation
+     */
     public function testAddsAdditionalProperties()
     {
         $location = new HeaderLocation('header');
@@ -50,5 +95,26 @@ class HeaderLocationTest extends TestCase
         $header = $request->getHeader('add');
         $this->assertIsArray($header);
         $this->assertEquals([0 => 'props'], $header);
+    }
+
+    /**
+     * @group RequestLocation
+     */
+    public function testAdditionalPropertiesSerializeScalarHeaderValues()
+    {
+        $location = new HeaderLocation('header');
+        $command = new Command('foo', ['foo' => 'bar']);
+        $command['add'] = 123;
+        $operation = new Operation([
+            'additionalParameters' => [
+                'location' => 'header',
+            ],
+        ]);
+        $request = new Request('POST', 'http://httbin.org');
+        $request = $location->after($command, $request, $operation);
+
+        $header = $request->getHeader('add');
+        $this->assertIsArray($header);
+        $this->assertEquals([0 => '123'], $header);
     }
 }

--- a/tests/RequestLocation/HeaderLocationTest.php
+++ b/tests/RequestLocation/HeaderLocationTest.php
@@ -79,6 +79,38 @@ class HeaderLocationTest extends TestCase
     /**
      * @group RequestLocation
      */
+    public function testVisitsLocationRejectsInvalidHeaderValue()
+    {
+        $location = new HeaderLocation('header');
+        $command = new Command('foo', ['foo' => null]);
+        $request = new Request('POST', 'http://httbin.org');
+        $param = new Parameter(['name' => 'foo']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header location values must be scalar or an array of scalars.');
+
+        $location->visit($command, $request, $param);
+    }
+
+    /**
+     * @group RequestLocation
+     */
+    public function testVisitsLocationRejectsInvalidArrayHeaderValue()
+    {
+        $location = new HeaderLocation('header');
+        $command = new Command('foo', ['foo' => ['bar', null]]);
+        $request = new Request('POST', 'http://httbin.org');
+        $param = new Parameter(['name' => 'foo']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header location values must be scalar or an array of scalars.');
+
+        $location->visit($command, $request, $param);
+    }
+
+    /**
+     * @group RequestLocation
+     */
     public function testAddsAdditionalProperties()
     {
         $location = new HeaderLocation('header');
@@ -116,5 +148,26 @@ class HeaderLocationTest extends TestCase
         $header = $request->getHeader('add');
         $this->assertIsArray($header);
         $this->assertEquals([0 => '123'], $header);
+    }
+
+    /**
+     * @group RequestLocation
+     */
+    public function testAdditionalPropertiesRejectInvalidHeaderValue()
+    {
+        $location = new HeaderLocation('header');
+        $command = new Command('foo', ['foo' => 'bar']);
+        $command['add'] = null;
+        $operation = new Operation([
+            'additionalParameters' => [
+                'location' => 'header',
+            ],
+        ]);
+        $request = new Request('POST', 'http://httbin.org');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header location values must be scalar or an array of scalars.');
+
+        $location->after($command, $request, $operation);
     }
 }


### PR DESCRIPTION
This serializes valid scalar header-location values before handing them to PSR-7. Invalid header-location values now fail clearly in Guzzle Services instead of leaking through to PSR-7 message creation.