### PR TITLE
[1.6] Deprecate non-string header location values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Deprecate the legacy `baseUrl` service description option; use `baseUri` instead
 * Deprecate the legacy `responseClass` operation option; use `responseModel` instead
+* Deprecate non-string header location values
 
 ## 1.5.1 - 2026-05-20
 

--- a/src/RequestLocation/HeaderLocation.php
+++ b/src/RequestLocation/HeaderLocation.php
@@ -64,15 +64,37 @@ class HeaderLocation extends AbstractLocation
      */
     private static function prepareHeaderValue($value)
     {
+        if (is_string($value)) {
+            return $value;
+        }
+
         if (is_scalar($value)) {
+            trigger_deprecation(
+                'guzzlehttp/guzzle-services',
+                '1.6',
+                'Passing %s as a header location value is deprecated; guzzlehttp/guzzle-services 2.0 requires string|string[].',
+                get_debug_type($value)
+            );
+
             return (string) $value;
         }
 
         if (is_array($value)) {
             foreach ($value as $key => $item) {
+                if (is_string($item)) {
+                    continue;
+                }
+
                 if (!is_scalar($item)) {
                     throw new \InvalidArgumentException('Header location values must be scalar or an array of scalars.');
                 }
+
+                trigger_deprecation(
+                    'guzzlehttp/guzzle-services',
+                    '1.6',
+                    'Passing %s inside a header location value array is deprecated; guzzlehttp/guzzle-services 2.0 requires string|string[].',
+                    get_debug_type($item)
+                );
 
                 $value[$key] = (string) $item;
             }

--- a/tests/RequestLocation/HeaderLocationTest.php
+++ b/tests/RequestLocation/HeaderLocationTest.php
@@ -34,46 +34,16 @@ class HeaderLocationTest extends TestCase
     /**
      * @group RequestLocation
      */
-    public function testVisitsLocationSerializesScalarHeaderValues()
-    {
-        $location = new HeaderLocation('header');
-        $param = new Parameter(['name' => 'foo']);
-
-        $request = $location->visit(
-            new Command('foo', ['foo' => 123]),
-            new Request('POST', 'http://httbin.org'),
-            $param
-        );
-        $this->assertEquals([0 => '123'], $request->getHeader('foo'));
-
-        $request = $location->visit(
-            new Command('foo', ['foo' => true]),
-            new Request('POST', 'http://httbin.org'),
-            $param
-        );
-        $this->assertEquals([0 => '1'], $request->getHeader('foo'));
-
-        $request = $location->visit(
-            new Command('foo', ['foo' => false]),
-            new Request('POST', 'http://httbin.org'),
-            $param
-        );
-        $this->assertEquals([0 => ''], $request->getHeader('foo'));
-    }
-
-    /**
-     * @group RequestLocation
-     */
     public function testVisitsLocationSerializesArrayHeaderValues()
     {
         $location = new HeaderLocation('header');
-        $command = new Command('foo', ['foo' => ['bar', 123, true, false]]);
+        $command = new Command('foo', ['foo' => ['bar', 'baz']]);
         $request = new Request('POST', 'http://httbin.org');
         $param = new Parameter(['name' => 'foo']);
 
         $request = $location->visit($command, $request, $param);
 
-        $this->assertEquals([0 => 'bar', 1 => '123', 2 => '1', 3 => ''], $request->getHeader('foo'));
+        $this->assertEquals([0 => 'bar', 1 => 'baz'], $request->getHeader('foo'));
     }
 
     /**
@@ -127,27 +97,6 @@ class HeaderLocationTest extends TestCase
         $header = $request->getHeader('add');
         $this->assertIsArray($header);
         $this->assertEquals([0 => 'props'], $header);
-    }
-
-    /**
-     * @group RequestLocation
-     */
-    public function testAdditionalPropertiesSerializeScalarHeaderValues()
-    {
-        $location = new HeaderLocation('header');
-        $command = new Command('foo', ['foo' => 'bar']);
-        $command['add'] = 123;
-        $operation = new Operation([
-            'additionalParameters' => [
-                'location' => 'header',
-            ],
-        ]);
-        $request = new Request('POST', 'http://httbin.org');
-        $request = $location->after($command, $request, $operation);
-
-        $header = $request->getHeader('add');
-        $this->assertIsArray($header);
-        $this->assertEquals([0 => '123'], $header);
     }
 
     /**


### PR DESCRIPTION
This keeps the 1.x scalar serialization behavior, but starts warning when header location values are not already strings. That gives users a clear path before 2.0 requires strings or arrays of strings.