### PR TITLE
[2.0] Enforce header location string values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Drop support for PHP 7.2 and 7.3
 * Require `guzzlehttp/command` ^2.0, `guzzlehttp/guzzle` ^8.0, `guzzlehttp/psr7` ^3.0, and `guzzlehttp/uri-template` ^2.0
 * Default operations without an `httpMethod` to `GET` and reject invalid `httpMethod` values
+* Require header location values to be strings or arrays of strings
 
 ## 1.6.0 - UPCOMING
 

--- a/src/RequestLocation/HeaderLocation.php
+++ b/src/RequestLocation/HeaderLocation.php
@@ -68,40 +68,16 @@ class HeaderLocation extends AbstractLocation
             return $value;
         }
 
-        if (is_scalar($value)) {
-            trigger_deprecation(
-                'guzzlehttp/guzzle-services',
-                '1.6',
-                'Passing %s as a header location value is deprecated; guzzlehttp/guzzle-services 2.0 requires string|string[].',
-                get_debug_type($value)
-            );
-
-            return (string) $value;
-        }
-
         if (is_array($value)) {
-            foreach ($value as $key => $item) {
-                if (is_string($item)) {
-                    continue;
+            foreach ($value as $item) {
+                if (!is_string($item)) {
+                    throw new \InvalidArgumentException('Header location values must be strings or arrays of strings.');
                 }
-
-                if (!is_scalar($item)) {
-                    throw new \InvalidArgumentException('Header location values must be scalar or an array of scalars.');
-                }
-
-                trigger_deprecation(
-                    'guzzlehttp/guzzle-services',
-                    '1.6',
-                    'Passing %s inside a header location value array is deprecated; guzzlehttp/guzzle-services 2.0 requires string|string[].',
-                    get_debug_type($item)
-                );
-
-                $value[$key] = (string) $item;
             }
 
             return $value;
         }
 
-        throw new \InvalidArgumentException('Header location values must be scalar or an array of scalars.');
+        throw new \InvalidArgumentException('Header location values must be strings or arrays of strings.');
     }
 }

--- a/tests/RequestLocation/HeaderLocationTest.php
+++ b/tests/RequestLocation/HeaderLocationTest.php
@@ -34,7 +34,7 @@ class HeaderLocationTest extends TestCase
     /**
      * @group RequestLocation
      */
-    public function testVisitsLocationSerializesArrayHeaderValues()
+    public function testVisitsLocationAcceptsArrayHeaderValues()
     {
         $location = new HeaderLocation('header');
         $command = new Command('foo', ['foo' => ['bar', 'baz']]);
@@ -57,7 +57,23 @@ class HeaderLocationTest extends TestCase
         $param = new Parameter(['name' => 'foo']);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Header location values must be scalar or an array of scalars.');
+        $this->expectExceptionMessage('Header location values must be strings or arrays of strings.');
+
+        $location->visit($command, $request, $param);
+    }
+
+    /**
+     * @group RequestLocation
+     */
+    public function testVisitsLocationRejectsScalarHeaderValue()
+    {
+        $location = new HeaderLocation('header');
+        $command = new Command('foo', ['foo' => 123]);
+        $request = new Request('POST', 'http://httbin.org');
+        $param = new Parameter(['name' => 'foo']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header location values must be strings or arrays of strings.');
 
         $location->visit($command, $request, $param);
     }
@@ -68,12 +84,12 @@ class HeaderLocationTest extends TestCase
     public function testVisitsLocationRejectsInvalidArrayHeaderValue()
     {
         $location = new HeaderLocation('header');
-        $command = new Command('foo', ['foo' => ['bar', null]]);
+        $command = new Command('foo', ['foo' => ['bar', 123]]);
         $request = new Request('POST', 'http://httbin.org');
         $param = new Parameter(['name' => 'foo']);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Header location values must be scalar or an array of scalars.');
+        $this->expectExceptionMessage('Header location values must be strings or arrays of strings.');
 
         $location->visit($command, $request, $param);
     }
@@ -106,7 +122,7 @@ class HeaderLocationTest extends TestCase
     {
         $location = new HeaderLocation('header');
         $command = new Command('foo', ['foo' => 'bar']);
-        $command['add'] = null;
+        $command['add'] = 123;
         $operation = new Operation([
             'additionalParameters' => [
                 'location' => 'header',
@@ -115,7 +131,7 @@ class HeaderLocationTest extends TestCase
         $request = new Request('POST', 'http://httbin.org');
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Header location values must be scalar or an array of scalars.');
+        $this->expectExceptionMessage('Header location values must be strings or arrays of strings.');
 
         $location->after($command, $request, $operation);
     }


### PR DESCRIPTION
This removes the 1.x compatibility behavior for header location values. In 2.0 they now need to be strings or arrays of strings, so invalid values fail in Guzzle Services before PSR-7 message creation.