### PR TITLE
Deprecate empty header arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Deprecate the legacy `baseUrl` service description option; use `baseUri` instead
 * Deprecate the legacy `responseClass` operation option; use `responseModel` instead
-* Deprecate non-string header location values
+* Deprecate non-string and empty-array header location values
 
 ## 1.5.1 - 2026-05-20
 

--- a/src/RequestLocation/HeaderLocation.php
+++ b/src/RequestLocation/HeaderLocation.php
@@ -80,6 +80,16 @@ class HeaderLocation extends AbstractLocation
         }
 
         if (is_array($value)) {
+            if ($value === []) {
+                \trigger_deprecation(
+                    'guzzlehttp/guzzle-services',
+                    '1.6',
+                    'Passing an empty array as a header location value is deprecated; guzzlehttp/guzzle-services 2.0 requires string or a non-empty array of strings.'
+                );
+
+                return $value;
+            }
+
             foreach ($value as $key => $item) {
                 if (is_string($item)) {
                     continue;


### PR DESCRIPTION
Deprecates empty array header location values before they are rejected in 2.0.