### PR TITLE
Enforce non-empty header arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Remove the legacy `baseUrl` service description option; use `baseUri` instead
 * Remove the legacy `responseClass` operation option; use `responseModel` instead
 * Default operations without an `httpMethod` to `GET` and reject invalid `httpMethod` values
-* Require header location values to be strings or arrays of strings
+* Require header location values to be strings or non-empty arrays of strings
 * Return raw PSR-7 responses in the `response` result key when the `process` client option is `false`
 * Require custom implementations and subclasses of public service APIs to match native method signatures
 * Require custom parameter filters and extension points to accept exact value types instead of relying on scalar coercion

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -92,11 +92,14 @@ string or a non-string value throws `InvalidArgumentException`.
 
 #### Header Location Values
 
-Header location values must now be strings or arrays of strings. Guzzle Services
-1.x accepted scalar header values and cast them to strings.
+Header location values must now be strings or non-empty arrays of strings.
+Guzzle Services 1.x accepted scalar header values and cast them to strings, and
+accepted empty arrays as header values.
 
 Normalize header values before constructing commands if your application passes
-integers, floats, booleans, or other non-string values into header locations.
+integers, floats, booleans, or other non-string values into header locations. Use
+an empty string for an explicitly empty header value, or omit the command value
+when no header should be sent.
 
 #### Strict Types and Extension Points
 

--- a/tests/RequestLocation/HeaderLocationTest.php
+++ b/tests/RequestLocation/HeaderLocationTest.php
@@ -59,7 +59,7 @@ class HeaderLocationTest extends TestCase
         $param = new Parameter(['name' => 'foo']);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Header location values must be strings or arrays of strings.');
+        $this->expectExceptionMessage('Header location values must be strings or non-empty arrays of strings.');
 
         $location->visit($command, $request, $param);
     }
@@ -75,7 +75,7 @@ class HeaderLocationTest extends TestCase
         $param = new Parameter(['name' => 'foo']);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Header location values must be strings or arrays of strings.');
+        $this->expectExceptionMessage('Header location values must be strings or non-empty arrays of strings.');
 
         $location->visit($command, $request, $param);
     }
@@ -91,7 +91,23 @@ class HeaderLocationTest extends TestCase
         $param = new Parameter(['name' => 'foo']);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Header location values must be strings or arrays of strings.');
+        $this->expectExceptionMessage('Header location values must be strings or non-empty arrays of strings.');
+
+        $location->visit($command, $request, $param);
+    }
+
+    /**
+     * @group RequestLocation
+     */
+    public function testVisitsLocationRejectsEmptyArrayHeaderValue(): void
+    {
+        $location = new HeaderLocation('header');
+        $command = new Command('foo', ['foo' => []]);
+        $request = new Request('POST', 'http://httbin.org');
+        $param = new Parameter(['name' => 'foo']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header location values must be strings or non-empty arrays of strings.');
 
         $location->visit($command, $request, $param);
     }
@@ -133,7 +149,28 @@ class HeaderLocationTest extends TestCase
         $request = new Request('POST', 'http://httbin.org');
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Header location values must be strings or arrays of strings.');
+        $this->expectExceptionMessage('Header location values must be strings or non-empty arrays of strings.');
+
+        $location->after($command, $request, $operation);
+    }
+
+    /**
+     * @group RequestLocation
+     */
+    public function testAdditionalPropertiesRejectEmptyArrayHeaderValue(): void
+    {
+        $location = new HeaderLocation('header');
+        $command = new Command('foo', ['foo' => 'bar']);
+        $command['add'] = [];
+        $operation = new Operation([
+            'additionalParameters' => [
+                'location' => 'header',
+            ],
+        ]);
+        $request = new Request('POST', 'http://httbin.org');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header location values must be strings or non-empty arrays of strings.');
 
         $location->after($command, $request, $operation);
     }


### PR DESCRIPTION
Updates the 2.0 header location tests and changelog for empty array rejection.