### PR TITLE
[2.0] Limit XML response depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Return raw PSR-7 responses in the `response` result key when the `process` client option is `false`
 * Require custom implementations and subclasses of public service APIs to match native method signatures
 * Require custom parameter filters and extension points to accept exact value types instead of relying on scalar coercion
+* Limit XML response traversal and additional-property conversion to 512 nested elements by default
+* Honor the documented `GuzzleClient` `response_locations` option when building the default deserializer
 
 ## 1.6.0 - UPCOMING
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -110,7 +110,7 @@ deeply nested XML responses consuming excessive stack, CPU, or memory during
 conversion.
 
 Applications that consume trusted services with legitimately deeper XML can
-register a custom XML response location with a higher limit:
+register a custom XML response location with a higher traversal limit:
 
 ```php
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
@@ -132,7 +132,8 @@ $client = new GuzzleClient(
 
 Only raise this limit for responses from trusted services. This limit guards the
 recursive traversal and conversion stage after XML parsing; it is not a response
-body size limit.
+body size limit and does not relax libxml's own XML parser limits. Responses
+that exceed libxml parser limits will still fail before response traversal.
 
 #### Strict Types and Extension Points
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -101,6 +101,39 @@ integers, floats, booleans, or other non-string values into header locations. Us
 an empty string for an explicitly empty header value, or omit the command value
 when no header should be sent.
 
+#### XML Response Depth Limit
+
+XML response deserialization now rejects XML responses that exceed 512 nested
+elements during response traversal or additional-property conversion. This
+matches PHP's default `json_decode()` depth and protects applications from
+deeply nested XML responses consuming excessive stack, CPU, or memory during
+conversion.
+
+Applications that consume trusted services with legitimately deeper XML can
+register a custom XML response location with a higher limit:
+
+```php
+use GuzzleHttp\Command\Guzzle\GuzzleClient;
+use GuzzleHttp\Command\Guzzle\ResponseLocation\XmlLocation;
+
+$client = new GuzzleClient(
+    $httpClient,
+    $description,
+    null,
+    null,
+    null,
+    [
+        'response_locations' => [
+            'xml' => new XmlLocation('xml', 2048),
+        ],
+    ]
+);
+```
+
+Only raise this limit for responses from trusted services. This limit guards the
+recursive traversal and conversion stage after XML parsing; it is not a response
+body size limit.
+
 #### Strict Types and Extension Points
 
 Guzzle Services source and test files now declare strict types. This mostly

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -112,7 +112,7 @@ class GuzzleClient extends ServiceClient
 
         return $responseToResultTransformer !== null
             ? $responseToResultTransformer
-            : new Deserializer($this->description, $process);
+            : new Deserializer($this->description, $process, $this->config['response_locations'] ?? []);
     }
 
     /**

--- a/src/ResponseLocation/XmlLocation.php
+++ b/src/ResponseLocation/XmlLocation.php
@@ -14,15 +14,26 @@ use Psr\Http\Message\ResponseInterface;
  */
 class XmlLocation extends AbstractLocation
 {
+    public const DEFAULT_MAX_DEPTH = 512;
+
     /** @var \SimpleXMLElement|null XML document being visited */
     private ?\SimpleXMLElement $xml = null;
+
+    private int $maxDepth;
 
     /**
      * Set the name of the location
      */
-    public function __construct(string $locationName = 'xml')
-    {
+    public function __construct(
+        string $locationName = 'xml',
+        int $maxDepth = self::DEFAULT_MAX_DEPTH
+    ) {
+        if ($maxDepth < 1) {
+            throw new \InvalidArgumentException('XML max depth must be greater than 0');
+        }
+
         parent::__construct($locationName);
+        $this->maxDepth = $maxDepth;
     }
 
     public function before(
@@ -59,20 +70,22 @@ class XmlLocation extends AbstractLocation
         ResponseInterface $response,
         Parameter $model
     ): ResultInterface {
-        // Handle additional, undefined properties
-        $additional = $model->getAdditionalProperties();
-        if ($additional instanceof Parameter
-            && $additional->getLocation() == $this->locationName
-        ) {
-            $result = new Result(array_merge(
-                $result->toArray(),
-                self::xmlToArray($this->getXml())
-            ));
+        try {
+            // Handle additional, undefined properties
+            $additional = $model->getAdditionalProperties();
+            if ($additional instanceof Parameter
+                && $additional->getLocation() == $this->locationName
+            ) {
+                $result = new Result(array_merge(
+                    $result->toArray(),
+                    $this->xmlToArray($this->getXml())
+                ));
+            }
+
+            return $result;
+        } finally {
+            $this->xml = null;
         }
-
-        $this->xml = null;
-
-        return $result;
     }
 
     public function visit(
@@ -93,7 +106,8 @@ class XmlLocation extends AbstractLocation
         if (count($children)) {
             $result[$param->getName()] = $this->recursiveProcess(
                 $param,
-                $children
+                $children,
+                1
             );
         }
 
@@ -109,6 +123,13 @@ class XmlLocation extends AbstractLocation
         return $this->xml;
     }
 
+    private function guardDepth(int $nesting): void
+    {
+        if ($nesting >= $this->maxDepth) {
+            throw new \RuntimeException("XML response exceeds maximum depth of {$this->maxDepth}");
+        }
+    }
+
     /**
      * Recursively process a parameter while applying filters
      *
@@ -119,15 +140,18 @@ class XmlLocation extends AbstractLocation
      */
     private function recursiveProcess(
         Parameter $param,
-        \SimpleXMLElement $node
+        \SimpleXMLElement $node,
+        int $nesting
     ) {
+        $this->guardDepth($nesting);
+
         $result = [];
         $type = $param->getType();
 
         if ($type == 'object') {
-            $result = $this->processObject($param, $node);
+            $result = $this->processObject($param, $node, $nesting);
         } elseif ($type == 'array') {
-            $result = $this->processArray($param, $node);
+            $result = $this->processArray($param, $node, $nesting);
         } else {
             // We are probably handling a flat data node (i.e. string or
             // integer), so let's check if it's childless, which indicates a
@@ -146,7 +170,7 @@ class XmlLocation extends AbstractLocation
         return $result;
     }
 
-    private function processArray(Parameter $param, \SimpleXMLElement $node): array
+    private function processArray(Parameter $param, \SimpleXMLElement $node, int $nesting): array
     {
         // Cast to an array if the value was a string, but should be an array
         $items = $param->getItems();
@@ -165,14 +189,14 @@ class XmlLocation extends AbstractLocation
         if ($sentAs === null) {
             // A general collection of nodes
             foreach ($node as $child) {
-                $result[] = $this->recursiveProcess($items, $child);
+                $result[] = $this->recursiveProcess($items, $child, $nesting + 1);
             }
         } else {
             // A collection of named, repeating nodes
             // (i.e. <collection><foo></foo><foo></foo></collection>)
             $children = $node->children($ns, true)->{$sentAs};
             foreach ($children as $child) {
-                $result[] = $this->recursiveProcess($items, $child);
+                $result[] = $this->recursiveProcess($items, $child, $nesting + 1);
             }
         }
 
@@ -185,7 +209,7 @@ class XmlLocation extends AbstractLocation
      * @param Parameter         $param API parameter being parsed
      * @param \SimpleXMLElement $node  Value to process
      */
-    private function processObject(Parameter $param, \SimpleXMLElement $node): array
+    private function processObject(Parameter $param, \SimpleXMLElement $node, int $nesting): array
     {
         $result = $knownProps = $knownAttributes = [];
 
@@ -212,7 +236,8 @@ class XmlLocation extends AbstractLocation
                     $childNode = $node->children($ns, true)->{$sentAs};
                     $result[$name] = $this->recursiveProcess(
                         $property,
-                        $childNode
+                        $childNode,
+                        $nesting + 1
                     );
                 }
             }
@@ -227,14 +252,15 @@ class XmlLocation extends AbstractLocation
                 if (!isset($knownProps[$sentAs])) {
                     $result[$sentAs] = $this->recursiveProcess(
                         $additional,
-                        $childNode
+                        $childNode,
+                        $nesting + 1
                     );
                 }
             }
         } elseif ($additional === null || $additional === true) {
             // Blindly transform the XML into an array preserving as much data
             // as possible. Remove processed, aliased properties.
-            $array = array_diff_key(self::xmlToArray($node), $knownProps);
+            $array = array_diff_key($this->xmlToArray($node, null, $nesting), $knownProps);
             // Remove @attributes that were explicitly plucked from the
             // attributes list.
             if (isset($array['@attributes']) && $knownAttributes) {
@@ -256,11 +282,13 @@ class XmlLocation extends AbstractLocation
      *
      * @return array
      */
-    private static function xmlToArray(
+    private function xmlToArray(
         \SimpleXMLElement $xml,
         ?string $ns = null,
         int $nesting = 0
     ) {
+        $this->guardDepth($nesting);
+
         $result = [];
         $children = $xml->children($ns, true);
 
@@ -269,7 +297,7 @@ class XmlLocation extends AbstractLocation
                 ? (array) $child->attributes()
                 : (array) $child->attributes($ns, true);
             if (!isset($result[$name])) {
-                $childArray = self::xmlToArray($child, $ns, $nesting + 1);
+                $childArray = $this->xmlToArray($child, $ns, $nesting + 1);
                 $result[$name] = $attributes
                     ? array_merge($attributes, $childArray)
                     : $childArray;
@@ -285,7 +313,7 @@ class XmlLocation extends AbstractLocation
                 $result[$name] = [];
                 $result[$name][] = $firstResult;
             }
-            $childArray = self::xmlToArray($child, $ns, $nesting + 1);
+            $childArray = $this->xmlToArray($child, $ns, $nesting + 1);
             if ($attributes) {
                 $result[$name][] = array_merge($attributes, $childArray);
             } else {

--- a/src/ResponseLocation/XmlLocation.php
+++ b/src/ResponseLocation/XmlLocation.php
@@ -93,25 +93,31 @@ class XmlLocation extends AbstractLocation
         ResponseInterface $response,
         Parameter $param
     ): ResultInterface {
-        $sentAs = $param->getWireName();
-        $ns = null;
-        if (null !== $sentAs && strstr($sentAs, ':')) {
-            list($ns, $sentAs) = explode(':', $sentAs);
+        try {
+            $sentAs = $param->getWireName();
+            $ns = null;
+            if (null !== $sentAs && strstr($sentAs, ':')) {
+                list($ns, $sentAs) = explode(':', $sentAs);
+            }
+
+            $xml = $this->getXml();
+            $children = $xml->children($ns, true)->{$sentAs};
+
+            // Process the primary property
+            if (count($children)) {
+                $result[$param->getName()] = $this->recursiveProcess(
+                    $param,
+                    $children,
+                    1
+                );
+            }
+
+            return $result;
+        } catch (\Throwable $e) {
+            $this->xml = null;
+
+            throw $e;
         }
-
-        $xml = $this->getXml();
-        $children = $xml->children($ns, true)->{$sentAs};
-
-        // Process the primary property
-        if (count($children)) {
-            $result[$param->getName()] = $this->recursiveProcess(
-                $param,
-                $children,
-                1
-            );
-        }
-
-        return $result;
     }
 
     private function getXml(): \SimpleXMLElement

--- a/tests/GuzzleClientTest.php
+++ b/tests/GuzzleClientTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
+use GuzzleHttp\Command\Guzzle\ResponseLocation\XmlLocation;
 use GuzzleHttp\Command\Result;
 use GuzzleHttp\Command\ResultInterface;
 use GuzzleHttp\Handler\MockHandler;
@@ -168,6 +169,47 @@ class GuzzleClientTest extends TestCase
             "<?xml version=\"1.0\"?>\n<Request><foo>Foo</foo><bar>Bar</bar><baz>Baz</baz></Request>\n",
             (string) $mock->getLastRequest()->getBody()
         );
+    }
+
+    public function testPassesConfiguredResponseLocationsToDeserializer(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], '<root><value>ok</value></root>'),
+        ]);
+        $description = new Description([
+            'baseUri' => 'http://httpbin.org',
+            'operations' => [
+                'getXml' => [
+                    'httpMethod' => 'GET',
+                    'uri' => '/xml',
+                    'responseModel' => 'XmlResponse',
+                ],
+            ],
+            'models' => [
+                'XmlResponse' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'value' => [
+                            'type' => 'string',
+                            'location' => 'xml',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $client = new GuzzleClient(
+            new HttpClient(['handler' => $mock]),
+            $description,
+            null,
+            null,
+            null,
+            ['response_locations' => ['xml' => new XmlLocation('xml', 1)]]
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('XML response exceeds maximum depth of 1');
+
+        $client->getXml();
     }
 
     public function testExecuteWithMultiPartLocation(): void

--- a/tests/ResponseLocation/XmlLocationTest.php
+++ b/tests/ResponseLocation/XmlLocationTest.php
@@ -188,6 +188,38 @@ class XmlLocationTest extends TestCase
     /**
      * @group ResponseLocation
      */
+    public function testDepthErrorClearsParsedResponse(): void
+    {
+        $location = new XmlLocation('xml', 2);
+        $parameter = new Parameter([
+            'name' => 'one',
+            'type' => 'object',
+            'location' => 'xml',
+            'additionalProperties' => false,
+            'properties' => [
+                'two' => ['type' => 'string'],
+            ],
+        ]);
+        $response = new Response(200, [], Psr7\Utils::streamFor('<root><one><two>value</two></one></root>'));
+
+        $location->before(new Result(), $response, new Parameter());
+
+        try {
+            $location->visit(new Result(), $response, $parameter);
+            $this->fail('Expected XML response depth to be rejected.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('XML response exceeds maximum depth of 2', $e->getMessage());
+        }
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('XML response has not been parsed');
+
+        $location->visit(new Result(), $response, $parameter);
+    }
+
+    /**
+     * @group ResponseLocation
+     */
     public function testAllowsKnownPropertiesAtConfiguredDepth(): void
     {
         $location = new XmlLocation('xml', 3);

--- a/tests/ResponseLocation/XmlLocationTest.php
+++ b/tests/ResponseLocation/XmlLocationTest.php
@@ -112,6 +112,106 @@ class XmlLocationTest extends TestCase
     /**
      * @group ResponseLocation
      */
+    public function testDefaultMaxDepthMatchesJsonDecodeDefault(): void
+    {
+        $this->assertSame(512, XmlLocation::DEFAULT_MAX_DEPTH);
+    }
+
+    /**
+     * @group ResponseLocation
+     */
+    public function testRejectsInvalidMaxDepth(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('XML max depth must be greater than 0');
+
+        new XmlLocation('xml', 0);
+    }
+
+    /**
+     * @group ResponseLocation
+     */
+    public function testRejectsAdditionalPropertiesBeyondConfiguredDepth(): void
+    {
+        $location = new XmlLocation('xml', 2);
+        $model = new Parameter(['additionalProperties' => ['location' => 'xml']]);
+        $response = new Response(200, [], Psr7\Utils::streamFor('<root><one><two>value</two></one></root>'));
+
+        $result = $location->before(new Result(), $response, $model);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('XML response exceeds maximum depth of 2');
+
+        $location->after($result, $response, $model);
+    }
+
+    /**
+     * @group ResponseLocation
+     */
+    public function testAllowsAdditionalPropertiesAtConfiguredDepth(): void
+    {
+        $location = new XmlLocation('xml', 3);
+        $model = new Parameter(['additionalProperties' => ['location' => 'xml']]);
+        $response = new Response(200, [], Psr7\Utils::streamFor('<root><one><two>value</two></one></root>'));
+
+        $result = $location->before(new Result(), $response, $model);
+        $result = $location->after($result, $response, $model);
+
+        $this->assertSame(['one' => ['two' => 'value']], $result->toArray());
+    }
+
+    /**
+     * @group ResponseLocation
+     */
+    public function testRejectsKnownPropertiesBeyondConfiguredDepth(): void
+    {
+        $location = new XmlLocation('xml', 2);
+        $parameter = new Parameter([
+            'name' => 'one',
+            'type' => 'object',
+            'location' => 'xml',
+            'additionalProperties' => false,
+            'properties' => [
+                'two' => ['type' => 'string'],
+            ],
+        ]);
+        $response = new Response(200, [], Psr7\Utils::streamFor('<root><one><two>value</two></one></root>'));
+
+        $location->before(new Result(), $response, new Parameter());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('XML response exceeds maximum depth of 2');
+
+        $location->visit(new Result(), $response, $parameter);
+    }
+
+    /**
+     * @group ResponseLocation
+     */
+    public function testAllowsKnownPropertiesAtConfiguredDepth(): void
+    {
+        $location = new XmlLocation('xml', 3);
+        $parameter = new Parameter([
+            'name' => 'one',
+            'type' => 'object',
+            'location' => 'xml',
+            'additionalProperties' => false,
+            'properties' => [
+                'two' => ['type' => 'string'],
+            ],
+        ]);
+        $response = new Response(200, [], Psr7\Utils::streamFor('<root><one><two>value</two></one></root>'));
+
+        $result = $location->before(new Result(), $response, new Parameter());
+        $result = $location->visit($result, $response, $parameter);
+        $result = $location->after($result, $response, new Parameter());
+
+        $this->assertSame(['one' => ['two' => 'value']], $result->toArray());
+    }
+
+    /**
+     * @group ResponseLocation
+     */
     public function testEnsuresFlatArraysAreFlat(): void
     {
         $param = new Parameter([


### PR DESCRIPTION
- add a configurable XML response traversal depth limit with a default of 512
- enforce the limit during schema-guided XML traversal and additional-property XML-to-array conversion
- honor the documented GuzzleClient response_locations config so consumers can customize the XML location
- document the 2.0-only behavior change in CHANGELOG.md and UPGRADING.md
