### PR TITLE
[2.0] Add operation-level response processing control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Default operations without an `httpMethod` to `GET` and reject invalid `httpMethod` values
 * Require header location values to be strings or non-empty arrays of strings
 * Return raw PSR-7 responses in the `response` result key when the `process` client option is `false`
+* Allow operations to override response processing with the `process` operation option
 * Require custom implementations and subclasses of public service APIs to match native method signatures
 * Require custom parameter filters and extension points to accept exact value types instead of relying on scalar coercion
 * Limit XML response traversal and additional-property conversion to 512 nested elements by default

--- a/README.md
+++ b/README.md
@@ -63,6 +63,40 @@ See [UPGRADING.md](UPGRADING.md) for upgrade notes.
 
 ## Cookbook
 
+### Disabling response processing for an operation
+
+By default, responses are parsed according to the operation's `responseModel`.
+For operations that return binary data or another response body that should not
+be parsed, set `process` to `false` on that operation:
+
+```php
+$description = new Description([
+	'operations' => [
+		'getMetadata' => [
+			'httpMethod' => 'GET',
+			'uri' => '/metadata/{id}',
+			'responseModel' => 'metadataResponse',
+		],
+		'getFile' => [
+			'httpMethod' => 'GET',
+			'uri' => '/files/{id}',
+			'process' => false,
+		]
+	]
+]);
+```
+
+When response processing is disabled, the raw PSR-7 response is returned in the
+result's `response` key:
+
+```php
+$result = $guzzleClient->getFile(['id' => 123]);
+$response = $result['response'];
+```
+
+Operation-level `process` overrides the client-level `process` option. If an
+operation omits `process`, or sets it to `null`, it inherits the client setting.
+
 ### Changing the way query params are serialized
 
 By default, query params are serialized using strict RFC3986 rules, using `http_build_query` method. With this, array params are serialized this way:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -90,6 +90,19 @@ $operation->toArray()['httpMethod']; // 'GET'
 Explicit `httpMethod` values must now be non-empty strings. Passing an empty
 string or a non-string value throws `InvalidArgumentException`.
 
+#### Operation Response Processing
+
+`process` is now a first-class operation option. When set to `false`, response
+model parsing is disabled for that operation. When set to `true`, response model
+parsing is enabled for that operation even if the client-level `process` option
+is disabled. When omitted or set to `null`, the operation inherits the client
+setting.
+
+Existing service descriptions that used a custom top-level operation key named
+`process` should move that metadata under the operation's `data` key, or ensure
+the value is a boolean or `null` and intentionally controls response processing.
+Non-boolean `process` values now throw `InvalidArgumentException`.
+
 #### Header Location Values
 
 Header location values must now be strings or non-empty arrays of strings.

--- a/src/Deserializer.php
+++ b/src/Deserializer.php
@@ -69,13 +69,14 @@ class Deserializer
      */
     public function __invoke(ResponseInterface $response, RequestInterface $request, CommandInterface $command): ResultInterface
     {
-        // If processing is disabled, expose the raw response without parsing it.
-        if ($this->process === false) {
-            return new Result(['response' => $response]);
-        }
-
         $name = $command->getName();
         $operation = $this->description->getOperation($name);
+        $process = $operation->getProcess() ?? $this->process;
+
+        // If processing is disabled, expose the raw response without parsing it.
+        if ($process === false) {
+            return new Result(['response' => $response]);
+        }
 
         $this->handleErrorResponses($response, $request, $command, $operation);
 

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -31,6 +31,8 @@ class GuzzleClient extends ServiceClient
      *   effect.
      * - process: Specify if HTTP responses are parsed (defaults to true).
      *   When false, the raw response is returned in the command result.
+     *   Individual operations can override this setting with their own process
+     *   option.
      *   Changing this setting after the client has been created will have no
      *   effect.
      * - response_locations: Associative array of location types mapping to

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -36,6 +36,8 @@ class Operation implements ToArrayInterface
      * - documentationUrl: (string) Reference URL providing more information
      *   about the operation.
      * - responseModel: (string) The model name used for processing response.
+     * - process: (bool|null) Whether this operation's HTTP response should be
+     *   parsed. Null inherits the client setting.
      * - deprecated: (bool) Set to true if this is a deprecated command
      * - errorResponses: (array) Errors that could occur when executing the
      *   command. Array of hashes, each with a 'code' (the HTTP response code),
@@ -59,6 +61,7 @@ class Operation implements ToArrayInterface
             'httpMethod' => 'GET',
             'uri' => '',
             'responseModel' => null,
+            'process' => null,
             'notes' => '',
             'summary' => '',
             'documentationUrl' => null,
@@ -79,6 +82,13 @@ class Operation implements ToArrayInterface
             && (!is_string($config['httpMethod']) || $config['httpMethod'] === '')
         ) {
             throw new \InvalidArgumentException('httpMethod must be a non-empty string');
+        }
+
+        if (array_key_exists('process', $config)
+            && $config['process'] !== null
+            && !is_bool($config['process'])
+        ) {
+            throw new \InvalidArgumentException('process must be a boolean or null');
         }
 
         $this->config = $config + $defaults;
@@ -185,6 +195,14 @@ class Operation implements ToArrayInterface
     public function getResponseModel(): ?string
     {
         return $this->config['responseModel'];
+    }
+
+    /**
+     * Get whether this operation overrides response processing.
+     */
+    public function getProcess(): ?bool
+    {
+        return $this->config['process'];
     }
 
     /**

--- a/tests/DeserializerTest.php
+++ b/tests/DeserializerTest.php
@@ -86,6 +86,87 @@ class DeserializerTest extends TestCase
         self::assertInstanceOf(Result::class, $client->foo(['bar' => 'baz']));
     }
 
+    public function testOperationCanDisableResponseProcessing(): void
+    {
+        $rawResponse = new Response(200, ['Content-Type' => 'application/octet-stream'], 'raw');
+        $jsonResponse = new Response(200, ['Content-Type' => 'application/json'], '{"foo":"bar"}');
+        $mock = new MockHandler([$rawResponse, $jsonResponse]);
+
+        $description = new Description([
+            'operations' => [
+                'download' => [
+                    'uri' => 'http://httpbin.org/download',
+                    'httpMethod' => 'GET',
+                    'process' => false,
+                    'responseModel' => 'JsonResponse',
+                ],
+                'getJson' => [
+                    'uri' => 'http://httpbin.org/json',
+                    'httpMethod' => 'GET',
+                    'responseModel' => 'JsonResponse',
+                ],
+            ],
+            'models' => [
+                'JsonResponse' => [
+                    'type' => 'object',
+                    'additionalProperties' => [
+                        'location' => 'json',
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = new GuzzleClient(new HttpClient(['handler' => $mock]), $description);
+
+        $rawResult = $client->download();
+        $this->assertInstanceOf(Result::class, $rawResult);
+        $this->assertSame($rawResponse, $rawResult['response']);
+
+        $parsedResult = $client->getJson();
+        $this->assertInstanceOf(Result::class, $parsedResult);
+        $this->assertEquals(['foo' => 'bar'], $parsedResult->toArray());
+    }
+
+    public function testOperationCanEnableResponseProcessing(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], '{"foo":"bar"}'),
+        ]);
+
+        $description = new Description([
+            'operations' => [
+                'getJson' => [
+                    'uri' => 'http://httpbin.org/json',
+                    'httpMethod' => 'GET',
+                    'process' => true,
+                    'responseModel' => 'JsonResponse',
+                ],
+            ],
+            'models' => [
+                'JsonResponse' => [
+                    'type' => 'object',
+                    'additionalProperties' => [
+                        'location' => 'json',
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = new GuzzleClient(
+            new HttpClient(['handler' => $mock]),
+            $description,
+            null,
+            null,
+            null,
+            ['process' => false]
+        );
+
+        $result = $client->getJson();
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertEquals(['foo' => 'bar'], $result->toArray());
+    }
+
     public function testCreateExceptionWithCode(): void
     {
         $this->expectException(CustomCommandException::class);

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -143,6 +143,38 @@ class OperationTest extends TestCase
         $this->assertEquals('POST', $o->toArray()['httpMethod']);
     }
 
+    public function testDefaultsProcessToNull(): void
+    {
+        $o = new Operation();
+
+        $this->assertNull($o->getProcess());
+        $this->assertNull($o->toArray()['process']);
+    }
+
+    public function testCanDisableResponseProcessing(): void
+    {
+        $o = new Operation(['process' => false]);
+
+        $this->assertFalse($o->getProcess());
+        $this->assertFalse($o->toArray()['process']);
+    }
+
+    public function testCanEnableResponseProcessing(): void
+    {
+        $o = new Operation(['process' => true]);
+
+        $this->assertTrue($o->getProcess());
+        $this->assertTrue($o->toArray()['process']);
+    }
+
+    public function testEnsuresProcessIsBoolOrNull(): void
+    {
+        $this->expectExceptionMessage('process must be a boolean or null');
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Operation(['process' => 'false']);
+    }
+
     public function testEnsuresHttpMethodIsNotEmptyString(): void
     {
         $this->expectExceptionMessage('httpMethod must be a non-empty string');
@@ -218,6 +250,7 @@ class OperationTest extends TestCase
         $d = new Description([
             'operations' => [
                 'A' => [
+                    'process' => false,
                     'parameters' => [
                         'A' => [
                             'type' => 'object',
@@ -234,6 +267,7 @@ class OperationTest extends TestCase
                 ],
                 'C' => [
                     'extends' => 'B',
+                    'process' => true,
                     'summary' => 'Bar',
                     'parameters' => [
                         'B' => ['type' => 'number'],
@@ -244,6 +278,7 @@ class OperationTest extends TestCase
 
         $a = $d->getOperation('A');
         $this->assertEquals('GET', $a->getHttpMethod());
+        $this->assertFalse($a->getProcess());
         $this->assertEquals('foo', $a->getSummary());
         $this->assertTrue($a->hasParam('A'));
         $this->assertEquals('string', $a->getParam('B')->getType());
@@ -251,12 +286,14 @@ class OperationTest extends TestCase
         $b = $d->getOperation('B');
         $this->assertTrue($a->hasParam('A'));
         $this->assertEquals('POST', $b->getHttpMethod());
+        $this->assertFalse($b->getProcess());
         $this->assertEquals('Bar', $b->getSummary());
         $this->assertEquals('string', $a->getParam('B')->getType());
 
         $c = $d->getOperation('C');
         $this->assertTrue($a->hasParam('A'));
         $this->assertEquals('POST', $c->getHttpMethod());
+        $this->assertTrue($c->getProcess());
         $this->assertEquals('Bar', $c->getSummary());
         $this->assertEquals('number', $c->getParam('B')->getType());
     }


### PR DESCRIPTION
This adds support for setting `process` on individual operations, so clients that mostly parse JSON can still expose specific endpoints, such as file downloads, as raw PSR-7 responses. Operations inherit the client-level `process` setting by default, while `process: false` disables parsing for that operation and `process: true` enables it even when the client default is disabled. Because `process` is now a first-class operation option, the upgrade guide notes that existing custom top-level operation metadata using that name should move under `data` or intentionally use the new behavior.

Closes #172.