### PR TITLE
Preserve explicit null JSON response properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Deprecate the legacy `baseUrl` service description option; use `baseUri` instead
 * Deprecate the legacy `responseClass` operation option; use `responseModel` instead
 * Deprecate non-string and empty-array header location values
+* Preserve explicit `null` JSON response properties
 
 ## 1.5.1 - 2026-05-20
 

--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -64,7 +64,7 @@ class JsonLocation extends AbstractLocation
         $addLocation = $additional->getLocation() ?: $model->getLocation();
         if ($addLocation == $this->locationName) {
             foreach ($this->json as $prop => $val) {
-                if (!isset($result[$prop])) {
+                if (!array_key_exists($prop, $result->toArray())) {
                     // Only recurse if there is a type specified
                     $result[$prop] = $additional->getType()
                         ? $this->recurse($additional, $val)
@@ -94,7 +94,7 @@ class JsonLocation extends AbstractLocation
             // Treat as javascript array
             if ($name) {
                 // name provided, store it under a key in the array
-                $subArray = isset($this->json[$key]) ? $this->json[$key] : null;
+                $subArray = $key !== null && array_key_exists($key, $this->json) ? $this->json[$key] : null;
                 $result[$name] = $this->recurse($param, $subArray);
             } else {
                 // top-level `array` or an empty name
@@ -103,7 +103,7 @@ class JsonLocation extends AbstractLocation
                     $this->recurse($param, $this->json)
                 ));
             }
-        } elseif ($key !== null && isset($this->json[$key])) {
+        } elseif ($key !== null && array_key_exists($key, $this->json)) {
             $result[$name] = $this->recurse($param, $this->json[$key]);
         }
 

--- a/tests/ResponseLocation/JsonLocationTest.php
+++ b/tests/ResponseLocation/JsonLocationTest.php
@@ -20,6 +20,11 @@ use PHPUnit\Framework\TestCase;
  */
 class JsonLocationTest extends TestCase
 {
+    public static function markAdditional($value)
+    {
+        return 'additional';
+    }
+
     /**
      * @group ResponseLocation
      */
@@ -405,6 +410,101 @@ class JsonLocationTest extends TestCase
         ];
 
         $this->assertEquals($expected, $result->toArray());
+    }
+
+    /**
+     * @group ResponseLocation
+     */
+    public function testVisitsTopLevelNullResponseProperties()
+    {
+        $json = [
+            'link' => null,
+        ];
+
+        $body = Utils::jsonEncode($json);
+        $response = new Response(200, ['Content-Type' => 'application/json'], $body);
+        $mock = new MockHandler([$response]);
+
+        $httpClient = new Client(['handler' => $mock]);
+
+        $description = new Description([
+            'operations' => [
+                'foo' => [
+                    'uri' => 'http://httpbin.org',
+                    'httpMethod' => 'GET',
+                    'responseModel' => 'j',
+                ],
+            ],
+            'models' => [
+                'j' => [
+                    'type' => 'object',
+                    'location' => 'json',
+                    'properties' => [
+                        'link' => [
+                            'location' => 'json',
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $guzzle = new GuzzleClient($httpClient, $description);
+        /** @var ResultInterface $result */
+        $result = $guzzle->foo();
+
+        $this->assertEquals(['link' => null], $result->toArray());
+    }
+
+    /**
+     * @group ResponseLocation
+     */
+    public function testAdditionalPropertiesDoNotOverwriteNullResponseProperties()
+    {
+        $json = [
+            'known' => null,
+            'extra' => 'value',
+        ];
+
+        $body = Utils::jsonEncode($json);
+        $response = new Response(200, ['Content-Type' => 'application/json'], $body);
+        $mock = new MockHandler([$response]);
+
+        $httpClient = new Client(['handler' => $mock]);
+
+        $description = new Description([
+            'operations' => [
+                'foo' => [
+                    'uri' => 'http://httpbin.org',
+                    'httpMethod' => 'GET',
+                    'responseModel' => 'j',
+                ],
+            ],
+            'models' => [
+                'j' => [
+                    'type' => 'object',
+                    'location' => 'json',
+                    'properties' => [
+                        'known' => [
+                            'location' => 'json',
+                            'type' => 'string',
+                        ],
+                    ],
+                    'additionalProperties' => [
+                        'location' => 'json',
+                        'type' => 'string',
+                        'filters' => [__CLASS__.'::markAdditional'],
+                    ],
+                ],
+            ],
+        ]);
+        $guzzle = new GuzzleClient($httpClient, $description);
+        /** @var ResultInterface $result */
+        $result = $guzzle->foo();
+
+        $this->assertEquals([
+            'known' => null,
+            'extra' => 'additional',
+        ], $result->toArray());
     }
 
     /**


### PR DESCRIPTION
This fixes JSON response handling for fields that are present with an explicit `null` value. The JSON visitor now checks whether keys exist instead of relying on `isset`, so modeled null properties are preserved and `additionalProperties` does not treat them as missing.

Refs #165.