### PR TITLE
Add JSON null response test type declarations

### DIFF
--- a/tests/ResponseLocation/JsonLocationTest.php
+++ b/tests/ResponseLocation/JsonLocationTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  */
 class JsonLocationTest extends TestCase
 {
-    public static function markAdditional($value)
+    public static function markAdditional(string $value): string
     {
         return 'additional';
     }
@@ -417,7 +417,7 @@ class JsonLocationTest extends TestCase
     /**
      * @group ResponseLocation
      */
-    public function testVisitsTopLevelNullResponseProperties()
+    public function testVisitsTopLevelNullResponseProperties(): void
     {
         $json = [
             'link' => null,
@@ -460,7 +460,7 @@ class JsonLocationTest extends TestCase
     /**
      * @group ResponseLocation
      */
-    public function testAdditionalPropertiesDoNotOverwriteNullResponseProperties()
+    public function testAdditionalPropertiesDoNotOverwriteNullResponseProperties(): void
     {
         $json = [
             'known' => null,


### PR DESCRIPTION
This follows up on the 1.6 merge by adding the native parameter and return types expected on the 2.0 test suite to the JSON null response regression tests.