### PR TITLE
[2.0] Support multiple JSON response field types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Require header location values to be strings or non-empty arrays of strings
 * Return raw PSR-7 responses in the `response` result key when the `process` client option is `false`
 * Allow operations to override response processing with the `process` operation option
+* Support JSON response fields with multiple allowed `type` values
 * Require custom implementations and subclasses of public service APIs to match native method signatures
 * Require custom parameter filters and extension points to accept exact value types instead of relying on scalar coercion
 * Limit XML response traversal and additional-property conversion to 512 nested elements by default

--- a/README.md
+++ b/README.md
@@ -97,6 +97,38 @@ $response = $result['response'];
 Operation-level `process` overrides the client-level `process` option. If an
 operation omits `process`, or sets it to `null`, it inherits the client setting.
 
+### Modeling JSON response fields with multiple types
+
+Some JSON APIs return the same field with different types depending on the data.
+For example, a response field might be `null`, a string, or an array of strings.
+Model this by setting `type` to an array of allowed types:
+
+```php
+$description = new Description([
+	'operations' => [
+		'getMetadata' => [
+			'httpMethod' => 'GET',
+			'uri' => '/metadata/{id}',
+			'responseModel' => 'metadataResponse',
+		]
+	],
+	'models' => [
+		'metadataResponse' => [
+			'type' => 'object',
+			'location' => 'json',
+			'properties' => [
+				'value' => [
+					'type' => ['null', 'string', 'array'],
+					'items' => [
+						'type' => 'string',
+					],
+				],
+			],
+		],
+	],
+]);
+```
+
 ### Changing the way query params are serialized
 
 By default, query params are serialized using strict RFC3986 rules, using `http_build_query` method. With this, array params are serialized this way:

--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -119,16 +119,14 @@ class JsonLocation extends AbstractLocation
         }
 
         $result = [];
-        $type = $param->getType();
+        $type = $this->getJsonContainerType($param, $value);
 
         if ($type == 'array') {
             $items = $param->getItems();
             foreach ($value as $val) {
                 $result[] = $this->recurse($items, $val);
             }
-        } elseif ($type == 'object' && !isset($value[0])) {
-            // On the above line, we ensure that the array is associative and
-            // not numerically indexed
+        } elseif ($type == 'object') {
             if ($properties = $param->getProperties()) {
                 foreach ($properties as $property) {
                     $key = $property->getWireName();
@@ -159,5 +157,36 @@ class JsonLocation extends AbstractLocation
         }
 
         return $param->filter($result);
+    }
+
+    private function getJsonContainerType(Parameter $param, array $value): ?string
+    {
+        $types = (array) $param->getType();
+        $allowsArray = in_array('array', $types, true);
+        $allowsObject = in_array('object', $types, true);
+
+        if ($allowsArray && !$allowsObject) {
+            return 'array';
+        }
+
+        if ($allowsObject && !$allowsArray) {
+            return $this->isJsonObject($value) ? 'object' : null;
+        }
+
+        if ($allowsArray) {
+            return $this->isJsonList($value) ? 'array' : 'object';
+        }
+
+        return null;
+    }
+
+    private function isJsonList(array $value): bool
+    {
+        return array_values($value) === $value;
+    }
+
+    private function isJsonObject(array $value): bool
+    {
+        return $value === [] || !$this->isJsonList($value);
     }
 }

--- a/tests/ResponseLocation/JsonLocationTest.php
+++ b/tests/ResponseLocation/JsonLocationTest.php
@@ -509,6 +509,159 @@ class JsonLocationTest extends TestCase
         ], $result->toArray());
     }
 
+    public static function multipleTypeProvider(): array
+    {
+        return [
+            [
+                ['null', 'string', 'array'],
+                ['value' => null],
+                ['value' => null],
+            ],
+            [
+                ['null', 'string', 'array'],
+                ['value' => 'foo'],
+                ['value' => 'foo'],
+            ],
+            [
+                ['null', 'string', 'array'],
+                ['value' => ['a', 'b', 'c']],
+                ['value' => ['a', 'b', 'c']],
+            ],
+            [
+                ['null', 'string', 'object', 'array'],
+                ['value' => ['a', 'b', 'c']],
+                ['value' => ['a', 'b', 'c']],
+            ],
+            [
+                ['null', 'string', 'array', 'object'],
+                ['value' => ['a', 'b', 'c']],
+                ['value' => ['a', 'b', 'c']],
+            ],
+            [
+                ['null', 'string', 'object', 'array'],
+                ['value' => ['worked' => true, 'failed' => false]],
+                ['value' => ['worked' => true, 'failed' => false]],
+            ],
+            [
+                ['null', 'string', 'array', 'object'],
+                ['value' => ['worked' => true, 'failed' => false]],
+                ['value' => ['worked' => true, 'failed' => false]],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider multipleTypeProvider
+     *
+     * @group ResponseLocation
+     */
+    public function testVisitsJsonPropertiesWithMultipleTypes(array $allowedTypes, array $json, array $expected): void
+    {
+        $body = Utils::jsonEncode($json);
+        $response = new Response(200, ['Content-Type' => 'application/json'], $body);
+        $mock = new MockHandler([$response]);
+
+        $httpClient = new Client(['handler' => $mock]);
+
+        $description = new Description([
+            'operations' => [
+                'foo' => [
+                    'uri' => 'http://httpbin.org',
+                    'httpMethod' => 'GET',
+                    'responseModel' => 'j',
+                ],
+            ],
+            'models' => [
+                'j' => [
+                    'type' => 'object',
+                    'location' => 'json',
+                    'properties' => [
+                        'value' => [
+                            'type' => $allowedTypes,
+                            'items' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $guzzle = new GuzzleClient($httpClient, $description);
+        /** @var ResultInterface $result */
+        $result = $guzzle->foo();
+
+        $this->assertEquals($expected, $result->toArray());
+    }
+
+    /**
+     * @group ResponseLocation
+     */
+    public function testVisitsMetadataResponseValuesWithMultipleTypes(): void
+    {
+        $json = [
+            'data' => [
+                [
+                    'attribute_id' => 1,
+                    'value' => null,
+                ],
+                [
+                    'attribute_id' => 2,
+                    'value' => 'foo',
+                ],
+                [
+                    'attribute_id' => 3,
+                    'value' => ['a', 'b'],
+                ],
+            ],
+        ];
+
+        $body = Utils::jsonEncode($json);
+        $response = new Response(200, ['Content-Type' => 'application/json'], $body);
+        $mock = new MockHandler([$response]);
+
+        $httpClient = new Client(['handler' => $mock]);
+
+        $description = new Description([
+            'operations' => [
+                'foo' => [
+                    'uri' => 'http://httpbin.org',
+                    'httpMethod' => 'GET',
+                    'responseModel' => 'AssetMetadataResponse',
+                ],
+            ],
+            'models' => [
+                'AssetMetadataResponse' => [
+                    'type' => 'object',
+                    'location' => 'json',
+                    'properties' => [
+                        'data' => [
+                            'type' => 'array',
+                            'items' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'attribute_id' => [
+                                        'type' => 'integer',
+                                    ],
+                                    'value' => [
+                                        'type' => ['null', 'string', 'array'],
+                                        'items' => [
+                                            'type' => 'string',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $guzzle = new GuzzleClient($httpClient, $description);
+        /** @var ResultInterface $result */
+        $result = $guzzle->foo();
+
+        $this->assertEquals($json, $result->toArray());
+    }
+
     /**
      * @group ResponseLocation
      */


### PR DESCRIPTION
This adds support for JSON response model fields whose `type` allows more than one value, such as fields that can be `null`, a string, or an array. The JSON response visitor now chooses array or object handling from the decoded JSON value rather than from the order of the configured types, so polymorphic response fields deserialize into the expected result shape.

Closes #165.