### PR TITLE
Fix validation-only additional parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.5.2 - UPCOMING
+
+* Fix request serialization for validation-only `additionalParameters`
+
 ## 1.5.1 - 2026-05-20
 
 * Replace deprecated Guzzle JSON helper functions

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -96,7 +96,12 @@ class Serializer
         // Ensure that the after() method is invoked for additionalParameters
         /** @var Parameter $additional */
         if ($additional = $operation->getAdditionalParameters()) {
-            $visitedLocations[$additional->getLocation()] = true;
+            if ($location = $additional->getLocation()) {
+                if (!isset($this->locations[$location])) {
+                    throw new \RuntimeException('No location registered for additionalParameters');
+                }
+                $visitedLocations[$location] = true;
+            }
         }
 
         // Call the after() method for each visited location

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -38,4 +38,26 @@ class SerializerTest extends TestCase
         $request = $serializer($command);
         $this->assertEquals('http://test.com/api/bar/foo', $request->getUri());
     }
+
+    public function testAllowsAdditionalParametersWithoutLocation()
+    {
+        $description = new Description([
+            'baseUri' => 'http://test.com',
+            'operations' => [
+                'test' => [
+                    'httpMethod' => 'GET',
+                    'uri' => '/api',
+                    'additionalParameters' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+        ]);
+
+        $command = new Command('test', ['extra' => 'value']);
+        $serializer = new Serializer($description);
+        /** @var Request $request */
+        $request = $serializer($command);
+        $this->assertEquals('http://test.com/api', $request->getUri());
+    }
 }


### PR DESCRIPTION
This fixes request serialization when additionalParameters is used only for validation and does not define a request location. The serializer now only invokes a request location for additional parameters when a location is configured.