### PR TITLE
Clean up merged tests

### DIFF
--- a/tests/SchemaValidatorTest.php
+++ b/tests/SchemaValidatorTest.php
@@ -103,9 +103,7 @@ class SchemaValidatorTest extends TestCase
 
     public function testValidatesToArrayInterfacePropertiesAfterConversion(): void
     {
-        $o = $this->getMockBuilder(ToArrayInterface::class)
-            ->setMethods(['toArray'])
-            ->getMockForAbstractClass();
+        $o = $this->createMock(ToArrayInterface::class);
         $o->expects($this->once())
             ->method('toArray')
             ->will($this->returnValue([]));

--- a/tests/SchemaValidatorTest.php
+++ b/tests/SchemaValidatorTest.php
@@ -101,7 +101,7 @@ class SchemaValidatorTest extends TestCase
         $this->assertTrue($this->validator->validate($p, $o));
     }
 
-    public function testValidatesToArrayInterfacePropertiesAfterConversion()
+    public function testValidatesToArrayInterfacePropertiesAfterConversion(): void
     {
         $o = $this->getMockBuilder(ToArrayInterface::class)
             ->setMethods(['toArray'])
@@ -121,7 +121,7 @@ class SchemaValidatorTest extends TestCase
         $this->assertEquals(['[test][foo] is a required string'], $this->validator->getErrors());
     }
 
-    public function testValidatesZeroNumberBounds()
+    public function testValidatesZeroNumberBounds(): void
     {
         $minimum = new Parameter([
             'name' => 'test',
@@ -144,7 +144,7 @@ class SchemaValidatorTest extends TestCase
         $this->assertEquals(['[test] must be less than or equal to 0'], $this->validator->getErrors());
     }
 
-    public function testValidatesZeroCollectionBounds()
+    public function testValidatesZeroCollectionBounds(): void
     {
         $string = new Parameter([
             'name' => 'test',

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -41,7 +41,7 @@ class SerializerTest extends TestCase
         $this->assertEquals('http://test.com/api/bar/foo', $request->getUri());
     }
 
-    public function testAllowsAdditionalParametersWithoutLocation()
+    public function testAllowsAdditionalParametersWithoutLocation(): void
     {
         $description = new Description([
             'baseUri' => 'http://test.com',


### PR DESCRIPTION
This adds native return types to the tests merged forward from 1.6 and updates the newly merged ToArrayInterface mock to use createMock(), keeping the 2.0 test suite consistent.