### PR TITLE
Enforce strict null schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Require custom parameter filters and extension points to accept exact value types instead of relying on scalar coercion
 * Limit XML response traversal and additional-property conversion to 512 nested elements by default
 * Honor the documented `GuzzleClient` `response_locations` option when building the default deserializer
+* Require `null` schema types to match only `null` values
 
 ## 1.6.0 - UPCOMING
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -114,6 +114,23 @@ integers, floats, booleans, or other non-string values into header locations. Us
 an empty string for an explicitly empty header value, or omit the command value
 when no header should be sent.
 
+#### Null Schema Values
+
+Schema parameters with `type` set to `'null'` now match only actual `null`
+values. Guzzle Services 1.x treated all falsy values, including `false`, `0`,
+`''`, and `[]`, as matching `null`.
+
+If a service description accepts specific falsy values, list those value types
+explicitly:
+
+```php
+// 1.x accepted false, 0, '', and [] as null.
+['type' => 'null']
+
+// 2.0: list every value shape that is accepted.
+['type' => ['null', 'boolean']]
+```
+
 #### XML Response Depth Limit
 
 XML response deserialization now rejects XML responses that exceed 512 nested

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -82,7 +82,7 @@ class SchemaValidator
                 return 'number';
             } elseif ($t == 'numeric' && is_numeric($value)) {
                 return 'numeric';
-            } elseif ($t == 'null' && !$value) {
+            } elseif ($t == 'null' && $value === null) {
                 return 'null';
             } elseif ($t == 'any') {
                 return 'any';

--- a/tests/SchemaValidatorTest.php
+++ b/tests/SchemaValidatorTest.php
@@ -281,9 +281,46 @@ class SchemaValidatorTest extends TestCase
         $this->assertEquals('boolean', $r->invoke($p, 'boolean', false));
         $this->assertEquals(false, $r->invoke($p, 'boolean', 'false'));
         $this->assertEquals('null', $r->invoke($p, 'null', null));
+        $this->assertEquals(false, $r->invoke($p, 'null', false));
+        $this->assertEquals(false, $r->invoke($p, 'null', 0));
+        $this->assertEquals(false, $r->invoke($p, 'null', ''));
+        $this->assertEquals(false, $r->invoke($p, 'null', []));
         $this->assertEquals(false, $r->invoke($p, 'null', 'abc'));
         $this->assertEquals('array', $r->invoke($p, 'array', []));
         $this->assertEquals(false, $r->invoke($p, 'array', 'foo'));
+    }
+
+    public function testNullTypeRejectsNonNullFalsyValues(): void
+    {
+        $param = new Parameter([
+            'name' => 'test',
+            'type' => 'null',
+        ]);
+
+        foreach ([false, 0, '', []] as $value) {
+            $this->assertFalse($this->validator->validate($param, $value));
+            $this->assertEquals(['[test] must be of type null'], $this->validator->getErrors());
+        }
+    }
+
+    public function testNullableUnionTypesAcceptExplicitFalsyTypes(): void
+    {
+        $cases = [
+            [['null', 'boolean'], false],
+            [['null', 'integer'], 0],
+            [['null', 'string'], ''],
+            [['null', 'array'], []],
+        ];
+
+        foreach ($cases as $case) {
+            $param = new Parameter([
+                'name' => 'test',
+                'type' => $case[0],
+            ]);
+            $value = $case[1];
+
+            $this->assertTrue($this->validator->validate($param, $value));
+        }
     }
 
     public function testValidatesFalseAdditionalProperties(): void


### PR DESCRIPTION
This requires null schema types to match only actual null values and documents the 2.0 upgrade impact for service descriptions that relied on falsy values matching null.