### PR TITLE
Document HTTP method casing in 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Require `guzzlehttp/command` ^2.0, `guzzlehttp/guzzle` ^8.0, `guzzlehttp/psr7` ^3.0, and `guzzlehttp/uri-template` ^2.0
 * Remove the legacy `baseUrl` service description option; use `baseUri` instead
 * Remove the legacy `responseClass` operation option; use `responseModel` instead
-* Default operations without an `httpMethod` to `GET` and reject invalid `httpMethod` values
+* Default operations without an `httpMethod` to `GET`, preserve explicit `httpMethod` casing, and reject invalid `httpMethod` values
 * Require header location values to be strings or non-empty arrays of strings
 * Return raw PSR-7 responses in the `response` result key when the `process` client option is `false`
 * Allow operations to override response processing with the `process` operation option

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -90,6 +90,12 @@ $operation->toArray()['httpMethod']; // 'GET'
 Explicit `httpMethod` values must now be non-empty strings. Passing an empty
 string or a non-string value throws `InvalidArgumentException`.
 
+Explicit `httpMethod` casing is now preserved when requests are serialized.
+Guzzle Services 2.0 uses Guzzle PSR-7 3.x, whose request implementation no
+longer uppercases explicitly provided methods. If a service description sets
+`httpMethod` to `get`, the serialized request method is `get`. Use `GET` in the
+service description when the service expects an uppercase method name.
+
 #### Operation Response Processing
 
 `process` is now a first-class operation option. When set to `false`, response

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -41,6 +41,25 @@ class SerializerTest extends TestCase
         $this->assertEquals('http://test.com/api/bar/foo', $request->getUri());
     }
 
+    public function testPreservesConfiguredHttpMethodCasing(): void
+    {
+        $description = new Description([
+            'baseUri' => 'http://test.com',
+            'operations' => [
+                'test' => [
+                    'httpMethod' => 'get',
+                    'uri' => '/api',
+                ],
+            ],
+        ]);
+
+        $command = new Command('test');
+        $serializer = new Serializer($description);
+        $request = $serializer($command);
+
+        $this->assertSame('get', $request->getMethod());
+    }
+
     public function testAllowsAdditionalParametersWithoutLocation(): void
     {
         $description = new Description([


### PR DESCRIPTION
This documents the HTTP method casing behavior inherited from Guzzle PSR-7 3.x. Explicit operation httpMethod values are passed through when service requests are serialized, so descriptions that configure get now produce requests with get rather than GET. The upgrade guide now calls this out, and the serializer test coverage locks in the behavior without adding method normalization.