### PR TITLE
Add validation handler return type

### DIFF
--- a/src/Handler/ValidatedDescriptionHandler.php
+++ b/src/Handler/ValidatedDescriptionHandler.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\Exception\CommandException;
 use GuzzleHttp\Command\Guzzle\DescriptionInterface;
 use GuzzleHttp\Command\Guzzle\SchemaValidator;
+use GuzzleHttp\Promise\PromiseInterface;
 
 /**
  * Handler used to validate command input against a service description.
@@ -29,9 +30,12 @@ class ValidatedDescriptionHandler
         $this->validator = $schemaValidator ?: new SchemaValidator();
     }
 
+    /**
+     * @param callable(CommandInterface): PromiseInterface $handler
+     */
     public function __invoke(callable $handler): \Closure
     {
-        return function (CommandInterface $command) use ($handler) {
+        return function (CommandInterface $command) use ($handler): PromiseInterface {
             $errors = [];
             $operation = $this->description->getOperation($command->getName());
 


### PR DESCRIPTION
This adds a native promise return type to the validation command middleware closure. The change aligns the middleware with the command handler contract used by Guzzle Command 2.