### PR TITLE
Improve services typing PHPDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Limit XML response traversal and additional-property conversion to 512 nested elements by default
 * Honor the documented `GuzzleClient` `response_locations` option when building the default deserializer
 * Require `null` schema types to match only `null` values
+* Improve PHPDoc for service client transformers, command handler stacks, and service description configuration arrays
 
 ## 1.6.0 - UPCOMING
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,25 @@ $guzzleClient = new GuzzleClient($client, $description, $serializer);
 
 You can also create your own serializer if you have specific needs.
 
+### Service client extension points
+
+`GuzzleHttp\Command\Guzzle\GuzzleClient` extends `guzzlehttp/command`'s service
+client and accepts optional callables for command serialization and response
+deserialization. The third constructor argument is a callable invoked as
+`callable(GuzzleHttp\Command\CommandInterface): Psr\Http\Message\RequestInterface`.
+The fourth constructor argument is a callable invoked as
+`callable(Psr\Http\Message\ResponseInterface, Psr\Http\Message\RequestInterface, GuzzleHttp\Command\CommandInterface): GuzzleHttp\Command\ResultInterface`.
+
+Any PHP callable is accepted, including invokable objects. The built-in
+`Serializer` and `Deserializer` classes are invokable, so they can be passed
+directly when you need custom request or response locations.
+
+The fifth constructor argument accepts a command `GuzzleHttp\HandlerStack` whose
+handlers follow the command handler contract
+`callable(GuzzleHttp\Command\CommandInterface): GuzzleHttp\Promise\PromiseInterface<GuzzleHttp\Command\ResultInterface, mixed>`.
+The sixth constructor argument is the service client configuration array. Known
+keys include `defaults`, `validate`, `process`, and `response_locations`.
+
 ## Security
 
 If you discover a security vulnerability within this package, please send an email to security@tidelift.com. All security vulnerabilities will be promptly addressed. Please do not disclose security-related issues publicly until a fix has been announced. Please see [Security Policy](https://github.com/guzzle/guzzle-services/security/policy) for more information.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -231,6 +231,29 @@ method signatures to remain compatible.
 Service description values should use the documented PHP types, such as strings
 for names and URIs, booleans for flags, and integers for min/max constraints.
 
+#### Generic Promise And Structured PHPDoc Types
+
+Guzzle Services command handler stack annotations now use generic
+`PromiseInterface<ResultInterface, mixed>` PHPDoc types. This is a
+static-analysis-only change and does not alter runtime behavior, but projects
+with stricter static analysis may see new or different diagnostics.
+
+Code using unparameterized promise types continues to work. If your project
+extends `GuzzleClient`, provides custom command middleware, or documents reusable
+command handlers, you may need to update your PHPDoc annotations to include
+promise fulfillment and rejection types.
+
+Service client transformer, service description, operation, parameter, and
+client config PHPDoc now uses structured array and callable shapes. This does not
+change runtime behavior, but stricter static analysis may now report invalid
+option keys, invalid option value types, or callback annotations that were
+previously hidden behind loose `array` or `callable` PHPDoc.
+
+Command-to-request transformers are documented as receiving `CommandInterface`.
+Response-to-result transformers are documented as receiving `ResponseInterface`,
+`RequestInterface`, and `CommandInterface`. Lower-arity userland callables
+continue to work at runtime when PHP accepts them.
+
 #### Command Client Dependency
 
 `GuzzleHttp\Command\Guzzle\GuzzleClient` continues to build on

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -254,11 +254,6 @@ Response-to-result transformers are documented as receiving `ResponseInterface`,
 `RequestInterface`, and `CommandInterface`. Lower-arity userland callables
 continue to work at runtime when PHP accepts them.
 
-#### Command Client Dependency
-
-`GuzzleHttp\Command\Guzzle\GuzzleClient` continues to build on
-`guzzlehttp/command`, but the required Command major version is now 2.x.
-
 #### Service Descriptions and URIs
 
 Guzzle PSR-7 3.x validates URI hosts, URI schemes, query values, and

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Call to function is_array\(\) with array\<mixed\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Description.php
+
+		-
 			message: '#^Negated boolean expression is always false\.$#'
 			identifier: booleanNot.alwaysFalse
 			count: 1
@@ -27,6 +33,12 @@ parameters:
 		-
 			message: '#^Result of && is always false\.$#'
 			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: src/Parameter.php
+
+		-
+			message: '#^Instanceof between GuzzleHttp\\Command\\Guzzle\\DescriptionInterface and GuzzleHttp\\Command\\Guzzle\\DescriptionInterface will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
 			count: 1
 			path: src/Parameter.php
 

--- a/src/Description.php
+++ b/src/Description.php
@@ -35,9 +35,16 @@ class Description implements DescriptionInterface
     private SchemaFormatter $formatter;
 
     /**
-     * @param array $config  Service description data
-     * @param array $options Custom options to apply to the description
-     *                       - formatter: Can provide a custom SchemaFormatter class
+     * @param array{
+     *     name?: string,
+     *     models?: array<array-key, array<array-key, mixed>>,
+     *     apiVersion?: string,
+     *     description?: string,
+     *     baseUri?: string|\Stringable,
+     *     operations?: array<array-key, array<array-key, mixed>>,
+     *     ...
+     * } $config Service description data.
+     * @param array{formatter?: SchemaFormatter} $options Custom options to apply to the description.
      *
      * @throws \InvalidArgumentException
      */
@@ -47,11 +54,18 @@ class Description implements DescriptionInterface
         // later used to determine extra data keys.
         static $defaultKeys = ['name', 'models', 'apiVersion', 'description'];
 
-        // Pull in the default configuration values
-        foreach ($defaultKeys as $key) {
-            if (isset($config[$key])) {
-                $this->{$key} = $config[$key];
-            }
+        // Pull in the default configuration values.
+        if (isset($config['name'])) {
+            $this->name = $config['name'];
+        }
+        if (isset($config['models'])) {
+            $this->models = $config['models'];
+        }
+        if (isset($config['apiVersion'])) {
+            $this->apiVersion = $config['apiVersion'];
+        }
+        if (isset($config['description'])) {
+            $this->description = $config['description'];
         }
 
         // Set the baseUri

--- a/src/Description.php
+++ b/src/Description.php
@@ -35,6 +35,9 @@ class Description implements DescriptionInterface
     private SchemaFormatter $formatter;
 
     /**
+     * The models and operations maps use PHP array keys. Numeric-string names
+     * are normalized to integer keys before the constructor receives them.
+     *
      * @param array{
      *     name?: string,
      *     models?: array<array-key, array<array-key, mixed>>,

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -43,6 +43,9 @@ class GuzzleClient extends ServiceClient
      * - response_locations: Associative array of location types mapping to
      *   ResponseLocationInterface objects.
      *
+     * The response_locations map uses PHP array keys. Numeric-string keys are
+     * normalized to integer keys before the constructor receives them.
+     *
      * @param ClientInterface                                                                         $client                      HTTP client to use.
      * @param DescriptionInterface                                                                    $description                 Guzzle service description.
      * @param (callable(CommandInterface): RequestInterface)|null                                     $commandToRequestTransformer Command-to-request transformer.

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -7,8 +7,13 @@ namespace GuzzleHttp\Command\Guzzle;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\Guzzle\Handler\ValidatedDescriptionHandler;
+use GuzzleHttp\Command\Guzzle\ResponseLocation\ResponseLocationInterface;
+use GuzzleHttp\Command\ResultInterface;
 use GuzzleHttp\Command\ServiceClient;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Default Guzzle web service client implementation.
@@ -38,9 +43,18 @@ class GuzzleClient extends ServiceClient
      * - response_locations: Associative array of location types mapping to
      *   ResponseLocationInterface objects.
      *
-     * @param ClientInterface      $client      HTTP client to use.
-     * @param DescriptionInterface $description Guzzle service description
-     * @param array                $config      Configuration options
+     * @param ClientInterface                                                                         $client                      HTTP client to use.
+     * @param DescriptionInterface                                                                    $description                 Guzzle service description.
+     * @param (callable(CommandInterface): RequestInterface)|null                                     $commandToRequestTransformer Command-to-request transformer.
+     * @param (callable(ResponseInterface, RequestInterface, CommandInterface): ResultInterface)|null $responseToResultTransformer Response-to-result transformer.
+     * @param HandlerStack<callable(CommandInterface): PromiseInterface<ResultInterface, mixed>>|null $commandHandlerStack         Command handler stack.
+     * @param array{
+     *     defaults?: array<array-key, mixed>,
+     *     validate?: bool,
+     *     process?: bool,
+     *     response_locations?: array<array-key, ResponseLocationInterface>,
+     *     ...
+     * } $config Configuration options.
      */
     public function __construct(
         ClientInterface $client,
@@ -94,7 +108,9 @@ class GuzzleClient extends ServiceClient
     /**
      * Returns the passed Serializer when set, a new instance otherwise
      *
-     * @return Serializer
+     * @param (callable(CommandInterface): RequestInterface)|null $commandToRequestTransformer
+     *
+     * @return callable(CommandInterface): RequestInterface
      */
     private function getSerializer(?callable $commandToRequestTransformer): callable
     {
@@ -106,7 +122,9 @@ class GuzzleClient extends ServiceClient
     /**
      * Returns the passed Deserializer when set, a new instance otherwise
      *
-     * @return Deserializer
+     * @param (callable(ResponseInterface, RequestInterface, CommandInterface): ResultInterface)|null $responseToResultTransformer
+     *
+     * @return callable(ResponseInterface, RequestInterface, CommandInterface): ResultInterface
      */
     private function getDeserializer(?callable $responseToResultTransformer): callable
     {

--- a/src/Handler/ValidatedDescriptionHandler.php
+++ b/src/Handler/ValidatedDescriptionHandler.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\Exception\CommandException;
 use GuzzleHttp\Command\Guzzle\DescriptionInterface;
 use GuzzleHttp\Command\Guzzle\SchemaValidator;
+use GuzzleHttp\Command\ResultInterface;
 use GuzzleHttp\Promise\PromiseInterface;
 
 /**
@@ -31,7 +32,9 @@ class ValidatedDescriptionHandler
     }
 
     /**
-     * @param callable(CommandInterface): PromiseInterface $handler
+     * @param callable(CommandInterface): PromiseInterface<ResultInterface, mixed> $handler
+     *
+     * @return \Closure(CommandInterface): PromiseInterface<ResultInterface, mixed>
      */
     public function __invoke(callable $handler): \Closure
     {

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -49,8 +49,29 @@ class Operation implements ToArrayInterface
      * - additionalParameters: (null|array) Parameter schema to use when an
      *   option is passed to the operation that is not in the schema
      *
-     * @param array                $config      Array of configuration data
-     * @param DescriptionInterface $description Service description used to resolve models if $ref tags are found
+     * @param array{
+     *     name?: string,
+     *     extends?: string,
+     *     httpMethod?: string,
+     *     uri?: string|null,
+     *     parameters?: array<array-key, array<array-key, mixed>>,
+     *     summary?: string,
+     *     notes?: string,
+     *     documentationUrl?: string|null,
+     *     responseModel?: string|null,
+     *     process?: bool|null,
+     *     deprecated?: bool,
+     *     errorResponses?: array<array-key, array{
+     *         code: int|string,
+     *         class: string,
+     *         phrase?: string,
+     *         ...
+     *     }>,
+     *     data?: array<array-key, mixed>,
+     *     additionalParameters?: array<array-key, mixed>|Parameter|null,
+     *     ...
+     * } $config Array of configuration data.
+     * @param DescriptionInterface|null $description Service description used to resolve models if $ref tags are found.
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -172,9 +172,8 @@ class Parameter implements ToArrayInterface
      * - $ref: (string) String referencing a service description model. The
      *   parameter is replaced by the schema contained in the model.
      *
-     * @param array $data    Array of data as seen in service descriptions
-     * @param array $options Options used when creating the parameter. You can
-     *                       specify a Guzzle service description in the 'description' key.
+     * @param array<array-key, mixed>                   $data    Array of data as seen in service descriptions.
+     * @param array{description?: DescriptionInterface} $options Options used when creating the parameter.
      *
      * @throws \InvalidArgumentException
      */

--- a/tests/GuzzleClientTest.php
+++ b/tests/GuzzleClientTest.php
@@ -790,6 +790,10 @@ class GuzzleClientTest extends TestCase
         $this->assertSame('BAZ', $query['baz']);
     }
 
+    /**
+     * @param array<array-key, mixed>                             $responses
+     * @param (callable(CommandInterface): RequestInterface)|null $commandToRequestTransformer
+     */
     private function getServiceClient(
         array $responses,
         ?MockHandler $mock = null,
@@ -813,6 +817,9 @@ class GuzzleClientTest extends TestCase
         );
     }
 
+    /**
+     * @return callable(CommandInterface): RequestInterface
+     */
     private function commandToRequestTransformer(): callable
     {
         return function (CommandInterface $command): Request {
@@ -823,6 +830,9 @@ class GuzzleClientTest extends TestCase
         };
     }
 
+    /**
+     * @return callable(ResponseInterface, RequestInterface, CommandInterface): ResultInterface
+     */
     private function responseToResultTransformer(): callable
     {
         return function (ResponseInterface $response, RequestInterface $request, CommandInterface $command): Result {


### PR DESCRIPTION
This improves PHPDoc for service client transformers, command handler stacks, and service description configuration arrays. It also documents the static-analysis impact and mirrors the callable contracts in tests and README examples.