### PR TITLE
Add service parameter types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Limit XML response traversal and additional-property conversion to 512 nested elements by default
 * Honor the documented `GuzzleClient` `response_locations` option when building the default deserializer
 * Require `null` schema types to match only `null` values
+* Add native parameter types to `GuzzleClient::getCommand()` and `Parameter::has()`
 * Improve PHPDoc for service client transformers, command handler stacks, and service description configuration arrays
 
 ## 1.6.0 - UPCOMING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 * Limit XML response traversal and additional-property conversion to 512 nested elements by default
 * Honor the documented `GuzzleClient` `response_locations` option when building the default deserializer
 * Require `null` schema types to match only `null` values
-* Add native parameter types to `GuzzleClient::getCommand()` and `Parameter::has()`
 * Improve PHPDoc for service client transformers, command handler stacks, and service description configuration arrays
 
 ## 1.6.0 - UPCOMING

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -231,6 +231,10 @@ method signatures to remain compatible.
 Service description values should use the documented PHP types, such as strings
 for names and URIs, booleans for flags, and integers for min/max constraints.
 
+`Parameter::has()` now requires a string property name. Passing arrays, objects,
+integers, or other non-string values now raises `TypeError` instead of the
+previous `InvalidArgumentException`.
+
 #### Generic Promise And Structured PHPDoc Types
 
 Guzzle Services command handler stack annotations now use generic

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -219,10 +219,11 @@ explicitly before calling those functions.
 
 #### Native Signatures
 
-Guzzle Services 2.0 adds native parameter, property, and return types to public
-interfaces, request and response locations, serializers, deserializers,
-validators, and formatters. Custom implementations and subclasses must update
-method signatures to remain compatible.
+Guzzle Services 2.0 adds native parameter, property, and return types across
+public service APIs, including interfaces, `GuzzleClient`, service description
+objects, request and response locations, serializers, deserializers, validators,
+and formatters. Custom implementations and subclasses must update method
+signatures to remain compatible.
 
 `GuzzleClient` command execution now returns `ResultInterface` values. When the
 `process` client option is `false`, the raw PSR-7 response is available as the
@@ -230,10 +231,6 @@ method signatures to remain compatible.
 
 Service description values should use the documented PHP types, such as strings
 for names and URIs, booleans for flags, and integers for min/max constraints.
-
-`Parameter::has()` now requires a string property name. Passing arrays, objects,
-integers, or other non-string values now raises `TypeError` instead of the
-previous `InvalidArgumentException`.
 
 #### Generic Promise And Structured PHPDoc Types
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,32 +13,20 @@ parameters:
 			path: src/Deserializer.php
 
 		-
-			message: '#^Call to function is_object\(\) with \*NEVER\* will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Parameter.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Parameter.php
-
-		-
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
 			count: 2
 			path: src/Parameter.php
 
 		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
+			message: '#^Instanceof between GuzzleHttp\\Command\\Guzzle\\DescriptionInterface and GuzzleHttp\\Command\\Guzzle\\DescriptionInterface will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
 			count: 1
 			path: src/Parameter.php
 
 		-
-			message: '#^Instanceof between GuzzleHttp\\Command\\Guzzle\\DescriptionInterface and GuzzleHttp\\Command\\Guzzle\\DescriptionInterface will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
 			count: 1
 			path: src/Parameter.php
 

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -79,11 +79,9 @@ class GuzzleClient extends ServiceClient
     /**
      * Returns the command if valid; otherwise an Exception
      *
-     * @param string $name
-     *
      * @throws \InvalidArgumentException
      */
-    public function getCommand($name, array $args = []): CommandInterface
+    public function getCommand(string $name, array $args = []): CommandInterface
     {
         if (!$this->description->hasOperation($name)) {
             $name = ucfirst($name);

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -611,15 +611,9 @@ class Parameter implements ToArrayInterface
 
     /**
      * Check if a parameter has a specific variable and if it set.
-     *
-     * @param string $var
      */
-    public function has($var): bool
+    public function has(string $var): bool
     {
-        if (!is_string($var)) {
-            throw new \InvalidArgumentException('Expected a string. Got: '.(is_object($var) ? get_class($var) : gettype($var)));
-        }
-
         return isset($this->{$var}) && !empty($this->{$var});
     }
 }

--- a/tests/ParameterTest.php
+++ b/tests/ParameterTest.php
@@ -404,17 +404,6 @@ class ParameterTest extends TestCase
         $this->assertEquals($data, $p->toArray());
     }
 
-    public function testThrowsWhenNotPassString(): void
-    {
-        $this->expectExceptionMessage('Expected a string. Got: array');
-        $this->expectException(\InvalidArgumentException::class);
-        $emptyParam = new Parameter();
-        $this->assertFalse($emptyParam->has([]));
-        $this->assertFalse($emptyParam->has(new \stdClass()));
-        $this->assertFalse($emptyParam->has('1'));
-        $this->assertFalse($emptyParam->has(1));
-    }
-
     public function testHasReturnsFalseForWrongOrEmptyValues(): void
     {
         $emptyParam = new Parameter();


### PR DESCRIPTION
This adds native parameter types to service command lookup and parameter property checks and documents the stricter Parameter::has input requirement.