### PR TITLE
Document parameter schema PHPDoc shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Limit XML response traversal and additional-property conversion to 512 nested elements by default
 * Honor the documented `GuzzleClient` `response_locations` option when building the default deserializer
 * Require `null` schema types to match only `null` values
-* Improve PHPDoc for service client transformers, command handler stacks, and service description configuration arrays
+* Improve PHPDoc for service client transformers, command handler stacks, and service description, operation, and parameter schema arrays
 
 ## 1.6.0 - UPCOMING
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -252,6 +252,9 @@ change runtime behavior, but stricter static analysis may now report invalid
 option keys, invalid option value types, or callback annotations that were
 previously hidden behind loose `array` or `callable` PHPDoc.
 
+If your project documents reusable service description, operation, or parameter
+schema arrays, update those PHPDoc annotations to match the supported shapes.
+
 Command-to-request transformers are documented as receiving `CommandInterface`.
 Response-to-result transformers are documented as receiving `ResponseInterface`,
 `RequestInterface`, and `CommandInterface`. Lower-arity userland callables


### PR DESCRIPTION
Clarifies that the 2.0 PHPDoc improvements include operation and parameter schema array shapes and notes the static-analysis impact for projects documenting reusable schema arrays.