### PR TITLE
Fix parameter has value checks

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -260,6 +260,15 @@ Response-to-result transformers are documented as receiving `ResponseInterface`,
 `RequestInterface`, and `CommandInterface`. Lower-arity userland callables
 continue to work at runtime when PHP accepts them.
 
+#### Parameter Presence Checks
+
+`Parameter::has()` now treats explicit `0`, `'0'`, `0.0`, and `false` values as
+present. It returns `false` for unset values, `null`, empty strings, and empty
+arrays.
+
+If your application calls `Parameter::has()` as a truthiness check, update that
+code to fetch the value and compare it explicitly.
+
 #### Service Descriptions and URIs
 
 Guzzle PSR-7 3.x validates URI hosts, URI schemes, query values, and

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -844,6 +844,12 @@ class Parameter implements ToArrayInterface
      */
     public function has(string $var): bool
     {
-        return isset($this->{$var}) && !empty($this->{$var});
+        if (!isset($this->{$var})) {
+            return false;
+        }
+
+        $value = $this->{$var};
+
+        return $value !== '' && $value !== [];
     }
 }

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -20,10 +20,8 @@ class Parameter implements ToArrayInterface
 
     private ?string $description = null;
 
-    private ?string $type = null;
-
-    /** @var array<array-key, string>|null */
-    private ?array $typeList = null;
+    /** @var string|array */
+    private $type;
 
     private bool $required = false;
 
@@ -59,11 +57,11 @@ class Parameter implements ToArrayInterface
 
     private array $properties = [];
 
-    private ?bool $additionalProperties = null;
+    /** @var array|bool|Parameter */
+    private $additionalProperties;
 
-    private ?Parameter $additionalPropertiesSchema = null;
-
-    private ?Parameter $items = null;
+    /** @var array|Parameter */
+    private $items;
 
     private ?string $format = null;
 
@@ -236,33 +234,12 @@ class Parameter implements ToArrayInterface
                 continue;
             }
 
-            if ($key === 'type') {
-                $this->setType($value);
-                $this->resolvedData[$key] = $value;
-
-                continue;
-            }
-
-            if ($key === 'additionalProperties') {
-                $this->setAdditionalProperties($value);
-                $this->resolvedData[$key] = $value;
-
-                continue;
-            }
-
-            if ($key === 'items') {
-                $this->setItems($value);
-                $this->resolvedData[$key] = $value;
-
-                continue;
-            }
-
             $this->{$key} = $value;
             $this->resolvedData[$key] = $value;
         }
 
-        if ($this->type === 'object' && $this->getAdditionalProperties() === null) {
-            $this->setAdditionalProperties(true);
+        if ($this->type == 'object' && $this->additionalProperties === null) {
+            $this->additionalProperties = true;
         }
     }
 
@@ -522,7 +499,7 @@ class Parameter implements ToArrayInterface
         }
 
         // Convert Boolean values
-        if ($this->getType() == 'boolean' && !is_bool($value)) {
+        if ($this->type == 'boolean' && !is_bool($value)) {
             $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
         }
 
@@ -578,11 +555,11 @@ class Parameter implements ToArrayInterface
     /**
      * Get the type(s) of the parameter
      *
-     * @return string|array<array-key, string>|null
+     * @return string|array
      */
     public function getType()
     {
-        return $this->typeList ?? $this->type;
+        return $this->type;
     }
 
     /**
@@ -691,12 +668,6 @@ class Parameter implements ToArrayInterface
             return $this->data;
         } elseif (isset($this->data[$name])) {
             return $this->data[$name];
-        } elseif ($name === 'type') {
-            return $this->getType();
-        } elseif ($name === 'additionalProperties') {
-            return $this->getAdditionalProperties();
-        } elseif ($name === 'items') {
-            return $this->getItems();
         } elseif (isset($this->{$name})) {
             return $this->{$name};
         }
@@ -768,7 +739,14 @@ class Parameter implements ToArrayInterface
      */
     public function getAdditionalProperties()
     {
-        return $this->additionalPropertiesSchema ?? $this->additionalProperties;
+        if (is_array($this->additionalProperties)) {
+            $this->additionalProperties = new static(
+                $this->additionalProperties,
+                ['description' => $this->serviceDescription]
+            );
+        }
+
+        return $this->additionalProperties;
     }
 
     /**
@@ -776,6 +754,13 @@ class Parameter implements ToArrayInterface
      */
     public function getItems(): ?Parameter
     {
+        if (is_array($this->items)) {
+            $this->items = new static(
+                $this->items,
+                ['description' => $this->serviceDescription]
+            );
+        }
+
         return $this->items;
     }
 
@@ -819,51 +804,6 @@ class Parameter implements ToArrayInterface
     }
 
     /**
-     * @param string|array<array-key, string>|null $type
-     */
-    private function setType($type): void
-    {
-        if (is_array($type)) {
-            $this->type = null;
-            $this->typeList = $type;
-
-            return;
-        }
-
-        $this->type = $type;
-        $this->typeList = null;
-    }
-
-    /**
-     * @param array<array-key, mixed>|bool|Parameter|null $additionalProperties
-     */
-    private function setAdditionalProperties($additionalProperties): void
-    {
-        $this->additionalProperties = null;
-        $this->additionalPropertiesSchema = null;
-
-        if ($additionalProperties === null || is_bool($additionalProperties)) {
-            $this->additionalProperties = $additionalProperties;
-
-            return;
-        }
-
-        $this->additionalPropertiesSchema = $additionalProperties instanceof self
-            ? $additionalProperties
-            : new static($additionalProperties, ['description' => $this->serviceDescription]);
-    }
-
-    /**
-     * @param array<array-key, mixed>|Parameter|null $items
-     */
-    private function setItems($items): void
-    {
-        $this->items = $items instanceof self || $items === null
-            ? $items
-            : new static($items, ['description' => $this->serviceDescription]);
-    }
-
-    /**
      * Add a filter to the parameter
      *
      * @param mixed $filter Method to filter the value through
@@ -904,37 +844,6 @@ class Parameter implements ToArrayInterface
      */
     public function has(string $var): bool
     {
-        if ($var === 'type') {
-            return self::hasValue($this->getType());
-        }
-
-        if ($var === 'additionalProperties') {
-            if (array_key_exists('additionalProperties', $this->resolvedData)) {
-                return self::hasValue($this->resolvedData['additionalProperties']);
-            }
-
-            return self::hasValue($this->getAdditionalProperties());
-        }
-
-        if ($var === 'items') {
-            return array_key_exists('items', $this->resolvedData)
-                && self::hasValue($this->resolvedData['items']);
-        }
-
-        if (!isset($this->{$var})) {
-            return false;
-        }
-
-        return self::hasValue($this->{$var});
-    }
-
-    /**
-     * @param mixed $value
-     */
-    private static function hasValue($value): bool
-    {
-        return $value !== null
-            && $value !== ''
-            && $value !== [];
+        return isset($this->{$var}) && !empty($this->{$var});
     }
 }

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -20,8 +20,10 @@ class Parameter implements ToArrayInterface
 
     private ?string $description = null;
 
-    /** @var string|array */
-    private $type;
+    private ?string $type = null;
+
+    /** @var array<array-key, string>|null */
+    private ?array $typeList = null;
 
     private bool $required = false;
 
@@ -57,11 +59,11 @@ class Parameter implements ToArrayInterface
 
     private array $properties = [];
 
-    /** @var array|bool|Parameter */
-    private $additionalProperties;
+    private ?bool $additionalProperties = null;
 
-    /** @var array|Parameter */
-    private $items;
+    private ?Parameter $additionalPropertiesSchema = null;
+
+    private ?Parameter $items = null;
 
     private ?string $format = null;
 
@@ -234,12 +236,33 @@ class Parameter implements ToArrayInterface
                 continue;
             }
 
+            if ($key === 'type') {
+                $this->setType($value);
+                $this->resolvedData[$key] = $value;
+
+                continue;
+            }
+
+            if ($key === 'additionalProperties') {
+                $this->setAdditionalProperties($value);
+                $this->resolvedData[$key] = $value;
+
+                continue;
+            }
+
+            if ($key === 'items') {
+                $this->setItems($value);
+                $this->resolvedData[$key] = $value;
+
+                continue;
+            }
+
             $this->{$key} = $value;
             $this->resolvedData[$key] = $value;
         }
 
-        if ($this->type == 'object' && $this->additionalProperties === null) {
-            $this->additionalProperties = true;
+        if ($this->type === 'object' && $this->getAdditionalProperties() === null) {
+            $this->setAdditionalProperties(true);
         }
     }
 
@@ -499,7 +522,7 @@ class Parameter implements ToArrayInterface
         }
 
         // Convert Boolean values
-        if ($this->type == 'boolean' && !is_bool($value)) {
+        if ($this->getType() == 'boolean' && !is_bool($value)) {
             $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
         }
 
@@ -555,11 +578,11 @@ class Parameter implements ToArrayInterface
     /**
      * Get the type(s) of the parameter
      *
-     * @return string|array
+     * @return string|array<array-key, string>|null
      */
     public function getType()
     {
-        return $this->type;
+        return $this->typeList ?? $this->type;
     }
 
     /**
@@ -668,6 +691,12 @@ class Parameter implements ToArrayInterface
             return $this->data;
         } elseif (isset($this->data[$name])) {
             return $this->data[$name];
+        } elseif ($name === 'type') {
+            return $this->getType();
+        } elseif ($name === 'additionalProperties') {
+            return $this->getAdditionalProperties();
+        } elseif ($name === 'items') {
+            return $this->getItems();
         } elseif (isset($this->{$name})) {
             return $this->{$name};
         }
@@ -739,14 +768,7 @@ class Parameter implements ToArrayInterface
      */
     public function getAdditionalProperties()
     {
-        if (is_array($this->additionalProperties)) {
-            $this->additionalProperties = new static(
-                $this->additionalProperties,
-                ['description' => $this->serviceDescription]
-            );
-        }
-
-        return $this->additionalProperties;
+        return $this->additionalPropertiesSchema ?? $this->additionalProperties;
     }
 
     /**
@@ -754,13 +776,6 @@ class Parameter implements ToArrayInterface
      */
     public function getItems(): ?Parameter
     {
-        if (is_array($this->items)) {
-            $this->items = new static(
-                $this->items,
-                ['description' => $this->serviceDescription]
-            );
-        }
-
         return $this->items;
     }
 
@@ -804,6 +819,51 @@ class Parameter implements ToArrayInterface
     }
 
     /**
+     * @param string|array<array-key, string>|null $type
+     */
+    private function setType($type): void
+    {
+        if (is_array($type)) {
+            $this->type = null;
+            $this->typeList = $type;
+
+            return;
+        }
+
+        $this->type = $type;
+        $this->typeList = null;
+    }
+
+    /**
+     * @param array<array-key, mixed>|bool|Parameter|null $additionalProperties
+     */
+    private function setAdditionalProperties($additionalProperties): void
+    {
+        $this->additionalProperties = null;
+        $this->additionalPropertiesSchema = null;
+
+        if ($additionalProperties === null || is_bool($additionalProperties)) {
+            $this->additionalProperties = $additionalProperties;
+
+            return;
+        }
+
+        $this->additionalPropertiesSchema = $additionalProperties instanceof self
+            ? $additionalProperties
+            : new static($additionalProperties, ['description' => $this->serviceDescription]);
+    }
+
+    /**
+     * @param array<array-key, mixed>|Parameter|null $items
+     */
+    private function setItems($items): void
+    {
+        $this->items = $items instanceof self || $items === null
+            ? $items
+            : new static($items, ['description' => $this->serviceDescription]);
+    }
+
+    /**
      * Add a filter to the parameter
      *
      * @param mixed $filter Method to filter the value through
@@ -844,6 +904,37 @@ class Parameter implements ToArrayInterface
      */
     public function has(string $var): bool
     {
-        return isset($this->{$var}) && !empty($this->{$var});
+        if ($var === 'type') {
+            return self::hasValue($this->getType());
+        }
+
+        if ($var === 'additionalProperties') {
+            if (array_key_exists('additionalProperties', $this->resolvedData)) {
+                return self::hasValue($this->resolvedData['additionalProperties']);
+            }
+
+            return self::hasValue($this->getAdditionalProperties());
+        }
+
+        if ($var === 'items') {
+            return array_key_exists('items', $this->resolvedData)
+                && self::hasValue($this->resolvedData['items']);
+        }
+
+        if (!isset($this->{$var})) {
+            return false;
+        }
+
+        return self::hasValue($this->{$var});
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function hasValue($value): bool
+    {
+        return $value !== null
+            && $value !== ''
+            && $value !== [];
     }
 }

--- a/tests/ParameterTest.php
+++ b/tests/ParameterTest.php
@@ -164,6 +164,8 @@ class ParameterTest extends TestCase
 
         $this->assertNull($p->getName());
         $this->assertNull($p->getDescription());
+        $this->assertNull($p->getType());
+        $this->assertNull($p->getDefault());
         $this->assertNull($p->getEnum());
         $this->assertNull($p->getPattern());
         $this->assertNull($p->getMinimum());
@@ -175,6 +177,8 @@ class ParameterTest extends TestCase
         $this->assertNull($p->getLocation());
         $this->assertNull($p->getSentAs());
         $this->assertNull($p->getFormat());
+        $this->assertNull($p->getAdditionalProperties());
+        $this->assertNull($p->getItems());
         $this->assertFalse($p->isRequired());
         $this->assertFalse($p->isStatic());
         $this->assertSame([], $p->getFilters());
@@ -191,6 +195,15 @@ class ParameterTest extends TestCase
     {
         $p = new Parameter(['type' => 'foo']);
         $this->assertEquals('foo', $p->getType());
+    }
+
+    public function testParsesArrayTypeValues(): void
+    {
+        $p = new Parameter(['type' => ['string', 'null']]);
+
+        $this->assertSame(['string', 'null'], $p->getType());
+        $this->assertSame(['string', 'null'], $p->getData('type'));
+        $this->assertTrue($p->has('type'));
     }
 
     public function testValidatesComplexFilters(): void
@@ -253,6 +266,19 @@ class ParameterTest extends TestCase
         $this->assertEquals(['name' => 'test'], $p->getData());
         $this->assertNull($p->getData('fjnweefe'));
         $this->assertEquals('hi!', $p->getData('extra'));
+    }
+
+    public function testCanRetrieveVirtualSchemaPropertiesUsingDataMethod(): void
+    {
+        $p = new Parameter([
+            'type' => 'array',
+            'items' => ['type' => 'string'],
+        ]);
+
+        $this->assertSame('array', $p->getData('type'));
+        $this->assertInstanceOf(Parameter::class, $p->getData('items'));
+        $this->assertNull($p->getData('additionalProperties'));
+        $this->assertTrue($p->has('items'));
     }
 
     public function testHasPattern(): void
@@ -481,5 +507,24 @@ class ParameterTest extends TestCase
         $this->assertTrue($p->has('maximum'));
         $this->assertTrue($p->has('minItems'));
         $this->assertTrue($p->has('maxItems'));
+    }
+
+    public function testHasOnlyRejectsNullEmptyStringAndEmptyArrayValues(): void
+    {
+        $p = new Parameter([
+            'description' => '0',
+            'minimum' => 0,
+            'type' => '0',
+        ]);
+
+        $this->assertTrue($p->has('description'));
+        $this->assertTrue($p->has('minimum'));
+        $this->assertTrue($p->has('type'));
+
+        $this->assertFalse((new Parameter(['description' => '']))->has('description'));
+        $this->assertFalse((new Parameter(['type' => '']))->has('type'));
+        $this->assertFalse((new Parameter(['type' => []]))->has('type'));
+        $this->assertFalse((new Parameter(['type' => 'array', 'items' => []]))->has('items'));
+        $this->assertTrue((new Parameter(['type' => 'object', 'additionalProperties' => false]))->has('additionalProperties'));
     }
 }

--- a/tests/ParameterTest.php
+++ b/tests/ParameterTest.php
@@ -164,8 +164,6 @@ class ParameterTest extends TestCase
 
         $this->assertNull($p->getName());
         $this->assertNull($p->getDescription());
-        $this->assertNull($p->getType());
-        $this->assertNull($p->getDefault());
         $this->assertNull($p->getEnum());
         $this->assertNull($p->getPattern());
         $this->assertNull($p->getMinimum());
@@ -177,8 +175,6 @@ class ParameterTest extends TestCase
         $this->assertNull($p->getLocation());
         $this->assertNull($p->getSentAs());
         $this->assertNull($p->getFormat());
-        $this->assertNull($p->getAdditionalProperties());
-        $this->assertNull($p->getItems());
         $this->assertFalse($p->isRequired());
         $this->assertFalse($p->isStatic());
         $this->assertSame([], $p->getFilters());
@@ -195,15 +191,6 @@ class ParameterTest extends TestCase
     {
         $p = new Parameter(['type' => 'foo']);
         $this->assertEquals('foo', $p->getType());
-    }
-
-    public function testParsesArrayTypeValues(): void
-    {
-        $p = new Parameter(['type' => ['string', 'null']]);
-
-        $this->assertSame(['string', 'null'], $p->getType());
-        $this->assertSame(['string', 'null'], $p->getData('type'));
-        $this->assertTrue($p->has('type'));
     }
 
     public function testValidatesComplexFilters(): void
@@ -266,19 +253,6 @@ class ParameterTest extends TestCase
         $this->assertEquals(['name' => 'test'], $p->getData());
         $this->assertNull($p->getData('fjnweefe'));
         $this->assertEquals('hi!', $p->getData('extra'));
-    }
-
-    public function testCanRetrieveVirtualSchemaPropertiesUsingDataMethod(): void
-    {
-        $p = new Parameter([
-            'type' => 'array',
-            'items' => ['type' => 'string'],
-        ]);
-
-        $this->assertSame('array', $p->getData('type'));
-        $this->assertInstanceOf(Parameter::class, $p->getData('items'));
-        $this->assertNull($p->getData('additionalProperties'));
-        $this->assertTrue($p->has('items'));
     }
 
     public function testHasPattern(): void
@@ -507,24 +481,5 @@ class ParameterTest extends TestCase
         $this->assertTrue($p->has('maximum'));
         $this->assertTrue($p->has('minItems'));
         $this->assertTrue($p->has('maxItems'));
-    }
-
-    public function testHasOnlyRejectsNullEmptyStringAndEmptyArrayValues(): void
-    {
-        $p = new Parameter([
-            'description' => '0',
-            'minimum' => 0,
-            'type' => '0',
-        ]);
-
-        $this->assertTrue($p->has('description'));
-        $this->assertTrue($p->has('minimum'));
-        $this->assertTrue($p->has('type'));
-
-        $this->assertFalse((new Parameter(['description' => '']))->has('description'));
-        $this->assertFalse((new Parameter(['type' => '']))->has('type'));
-        $this->assertFalse((new Parameter(['type' => []]))->has('type'));
-        $this->assertFalse((new Parameter(['type' => 'array', 'items' => []]))->has('items'));
-        $this->assertTrue((new Parameter(['type' => 'object', 'additionalProperties' => false]))->has('additionalProperties'));
     }
 }

--- a/tests/ParameterTest.php
+++ b/tests/ParameterTest.php
@@ -482,4 +482,23 @@ class ParameterTest extends TestCase
         $this->assertTrue($p->has('minItems'));
         $this->assertTrue($p->has('maxItems'));
     }
+
+    public function testHasRejectsOnlyNullEmptyStringAndEmptyArrayValues(): void
+    {
+        $p = new Parameter([
+            'description' => '0',
+            'minimum' => 0,
+            'type' => '0',
+            'additionalProperties' => false,
+        ]);
+
+        $this->assertTrue($p->has('description'));
+        $this->assertTrue($p->has('minimum'));
+        $this->assertTrue($p->has('type'));
+        $this->assertTrue($p->has('additionalProperties'));
+
+        $this->assertFalse((new Parameter(['description' => '']))->has('description'));
+        $this->assertFalse((new Parameter(['type' => '']))->has('type'));
+        $this->assertFalse((new Parameter(['type' => []]))->has('type'));
+    }
 }


### PR DESCRIPTION
This updates Parameter::has() on the 2.0 branch to treat only null, empty strings, and empty arrays as absent values. This is a 2.0-only behavior change: valid explicit values such as 0, '0', 0.0, and false are now reported as present. The 2.0 upgrade guide documents the behavior change.