### PR TITLE
Add SchemaValidator closure return type

### DIFF
--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -252,7 +252,7 @@ class SchemaValidator
 
             // Strings can have enums which are a list of predefined values
             if (($enum = $param->getEnum()) && !in_array($value, $enum)) {
-                $this->errors[] = "{$path} must be one of ".implode(' or ', array_map(function ($s) {
+                $this->errors[] = "{$path} must be one of ".implode(' or ', array_map(function ($s): string {
                     return '"'.addslashes($s).'"';
                 }, $enum));
             }


### PR DESCRIPTION
This adds a native string return type to the enum formatting closure in SchemaValidator.