### PR TITLE
Require PHP 8 polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "guzzlehttp/guzzle": "^7.10",
         "guzzlehttp/psr7": "^2.8",
         "guzzlehttp/uri-template": "^1.0.5",
-        "symfony/deprecation-contracts": "^2.5 || ^3.0"
+        "symfony/deprecation-contracts": "^2.5 || ^3.0",
+        "symfony/polyfill-php80": "^1.24"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",


### PR DESCRIPTION
This adds the PHP 8 polyfill because unreleased 1.6 code uses get_debug_type while still supporting PHP 7.