### PR TITLE
Normalize operation HTTP methods before PSR-7

### DIFF
--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -125,8 +125,22 @@ class Serializer
 
         // If command does not specify a template, assume the client's base URL.
         if (null === $operation->getUri()) {
+            /** @var mixed $method */
+            $method = $operation->getHttpMethod() ?: 'GET';
+            if (is_string($method)) {
+                $normalizedMethod = strtoupper($method);
+                if ($method !== $normalizedMethod) {
+                    \trigger_deprecation(
+                        'guzzlehttp/guzzle-services',
+                        '1.6',
+                        'Passing a non-uppercase operation "httpMethod" value to Serializer::createRequest() is deprecated; guzzlehttp/guzzle-services 2.0 will preserve HTTP method casing. Pass an uppercase method explicitly if uppercase is required.'
+                    );
+                    $method = $normalizedMethod;
+                }
+            }
+
             return new Request(
-                $operation->getHttpMethod() ?: 'GET',
+                $method,
                 $this->description->getBaseUri()
             );
         }
@@ -159,9 +173,22 @@ class Serializer
 
         // Expand the URI template.
         $uri = new Uri(UriTemplate::expand($operation->getUri(), $variables));
+        /** @var mixed $method */
+        $method = $operation->getHttpMethod() ?: 'GET';
+        if (is_string($method)) {
+            $normalizedMethod = strtoupper($method);
+            if ($method !== $normalizedMethod) {
+                \trigger_deprecation(
+                    'guzzlehttp/guzzle-services',
+                    '1.6',
+                    'Passing a non-uppercase operation "httpMethod" value to Serializer::createCommandWithUri() is deprecated; guzzlehttp/guzzle-services 2.0 will preserve HTTP method casing. Pass an uppercase method explicitly if uppercase is required.'
+                );
+                $method = $normalizedMethod;
+            }
+        }
 
         return new Request(
-            $operation->getHttpMethod() ?: 'GET',
+            $method,
             UriResolver::resolve($this->description->getBaseUri(), $uri)
         );
     }

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -36,7 +36,25 @@ class SerializerTest extends TestCase
         $serializer = new Serializer($description);
         /** @var Request $request */
         $request = $serializer($command);
+        $this->assertSame('GET', $request->getMethod());
         $this->assertEquals('http://test.com/api/bar/foo', $request->getUri());
+    }
+
+    public function testCreatesRequestWithUppercaseMethodWithoutUriTemplate()
+    {
+        $description = new Description([
+            'baseUri' => 'http://test.com',
+            'operations' => [
+                'test' => [
+                    'httpMethod' => 'POST',
+                ],
+            ],
+        ]);
+
+        $request = (new Serializer($description))(new Command('test'));
+
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertEquals('http://test.com', $request->getUri());
     }
 
     public function testAllowsAdditionalParametersWithoutLocation()


### PR DESCRIPTION
This updates the serializer so operation `httpMethod` values are normalized immediately before constructing PSR-7 requests. If a service description provides a non-uppercase method, guzzle-services now emits its own deprecation and keeps the effective 1.6 behavior of sending an uppercase method, avoiding the deprecation coming from PSR-7 instead. I also added safe serializer coverage for uppercase methods in both request creation paths.