### PR TITLE
Skip empty header arrays before PSR-7

### DIFF
--- a/src/RequestLocation/HeaderLocation.php
+++ b/src/RequestLocation/HeaderLocation.php
@@ -32,8 +32,12 @@ class HeaderLocation extends AbstractLocation
         Parameter $param
     ) {
         $value = $command[$param->getName()];
+        $prepared = self::prepareHeaderValue($param->filter($value));
+        if ($prepared === []) {
+            return $request;
+        }
 
-        return $request->withHeader($param->getWireName(), self::prepareHeaderValue($param->filter($value)));
+        return $request->withHeader($param->getWireName(), $prepared);
     }
 
     /**
@@ -49,7 +53,12 @@ class HeaderLocation extends AbstractLocation
         if ($additional && ($additional->getLocation() === $this->locationName)) {
             foreach ($command->toArray() as $key => $value) {
                 if (!$operation->hasParam($key)) {
-                    $request = $request->withHeader($key, self::prepareHeaderValue($additional->filter($value)));
+                    $prepared = self::prepareHeaderValue($additional->filter($value));
+                    if ($prepared === []) {
+                        continue;
+                    }
+
+                    $request = $request->withHeader($key, $prepared);
                 }
             }
         }


### PR DESCRIPTION
This keeps deprecated empty header arrays from being passed through to PSR-7 after guzzle-services has already handled them. The header location visitor now treats a prepared empty array as no header update, which preserves any existing request header and avoids turning the deprecated input into a second package deprecation. Additional header parameters with the same deprecated empty-array value are skipped for the same reason.