### PR TITLE
Harden serializer state after failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.3 - Upcoming
 
+* Harden request serialization state after failures
 * Preserve explicit `null` JSON response properties
 
 ## 1.5.2 - 2026-05-22

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -25,6 +25,9 @@ class Serializer
     /** @var RequestLocationInterface[] */
     private $locations;
 
+    /** @var RequestLocationInterface[] */
+    private $customRequestLocations;
+
     /** @var DescriptionInterface */
     private $description;
 
@@ -35,20 +38,8 @@ class Serializer
         DescriptionInterface $description,
         array $requestLocations = []
     ) {
-        static $defaultRequestLocations;
-        if (!$defaultRequestLocations) {
-            $defaultRequestLocations = [
-                'body' => new BodyLocation(),
-                'query' => new QueryLocation(),
-                'header' => new HeaderLocation(),
-                'json' => new JsonLocation(),
-                'xml' => new XmlLocation(),
-                'formParam' => new FormParamLocation(),
-                'multipart' => new MultiPartLocation(),
-            ];
-        }
-
-        $this->locations = $requestLocations + $defaultRequestLocations;
+        $this->customRequestLocations = $requestLocations;
+        $this->resetDefaultRequestLocations();
         $this->description = $description;
     }
 
@@ -59,7 +50,26 @@ class Serializer
     {
         $request = $this->createRequest($command);
 
-        return $this->prepareRequest($command, $request);
+        try {
+            return $this->prepareRequest($command, $request);
+        } catch (\Throwable $e) {
+            $this->resetDefaultRequestLocations();
+
+            throw $e;
+        }
+    }
+
+    private function resetDefaultRequestLocations()
+    {
+        $this->locations = $this->customRequestLocations + [
+            'body' => new BodyLocation(),
+            'query' => new QueryLocation(),
+            'header' => new HeaderLocation(),
+            'json' => new JsonLocation(),
+            'xml' => new XmlLocation(),
+            'formParam' => new FormParamLocation(),
+            'multipart' => new MultiPartLocation(),
+        ];
     }
 
     /**

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -10,8 +10,8 @@ use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\RequestLocation\RequestLocationInterface;
 use GuzzleHttp\Command\Guzzle\Serializer;
 use GuzzleHttp\Psr7\Request;
-use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * @covers \GuzzleHttp\Command\Guzzle\Serializer

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -3,9 +3,14 @@
 namespace GuzzleHttp\Tests\Command\Guzzle;
 
 use GuzzleHttp\Command\Command;
+use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\Guzzle\Description;
+use GuzzleHttp\Command\Guzzle\Operation;
+use GuzzleHttp\Command\Guzzle\Parameter;
+use GuzzleHttp\Command\Guzzle\RequestLocation\RequestLocationInterface;
 use GuzzleHttp\Command\Guzzle\Serializer;
 use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -59,5 +64,152 @@ class SerializerTest extends TestCase
         /** @var Request $request */
         $request = $serializer($command);
         $this->assertEquals('http://test.com/api', $request->getUri());
+    }
+
+    public function testDoesNotLeakJsonLocationStateAfterFailedSerialization()
+    {
+        $request = $this->serializeAfterFailure('json');
+
+        $this->assertSame('{"public":"ok"}', (string) $request->getBody());
+    }
+
+    public function testDoesNotLeakFormParamLocationStateAfterFailedSerialization()
+    {
+        $request = $this->serializeAfterFailure('formParam');
+
+        $this->assertSame('public=ok', (string) $request->getBody());
+    }
+
+    public function testDoesNotLeakMultipartLocationStateAfterFailedSerialization()
+    {
+        $body = (string) $this->serializeAfterFailure('multipart')->getBody();
+
+        $this->assertStringContainsString('name="public"', $body);
+        $this->assertStringContainsString('ok', $body);
+        $this->assertStringNotContainsString('name="secret"', $body);
+        $this->assertStringNotContainsString('TOPSECRET', $body);
+    }
+
+    public function testDoesNotLeakXmlLocationStateAfterFailedSerialization()
+    {
+        $body = (string) $this->serializeAfterFailure('xml')->getBody();
+
+        $this->assertStringContainsString('<public>ok</public>', $body);
+        $this->assertStringNotContainsString('secret', $body);
+        $this->assertStringNotContainsString('TOPSECRET', $body);
+    }
+
+    public function testSerializerInstancesDoNotShareDefaultRequestLocationState()
+    {
+        $description = $this->createFailedSerializationDescription('json');
+        $first = new Serializer($description, ['fail' => $this->createFailingRequestLocation()]);
+        $second = new Serializer($description);
+
+        $this->triggerFailedSerialization($first);
+        $request = $second(new Command('Next', ['public' => 'ok']));
+
+        $this->assertSame('{"public":"ok"}', (string) $request->getBody());
+    }
+
+    public function testCustomRequestLocationIsPreservedAfterFailedSerialization()
+    {
+        $customLocation = new class implements RequestLocationInterface {
+            public function visit(
+                CommandInterface $command,
+                RequestInterface $request,
+                Parameter $param
+            ) {
+                return $request->withHeader('X-Custom-Request-Location', $param->getWireName());
+            }
+
+            public function after(
+                CommandInterface $command,
+                RequestInterface $request,
+                Operation $operation
+            ) {
+                return $request;
+            }
+        };
+
+        $serializer = new Serializer(
+            $this->createFailedSerializationDescription('json'),
+            ['fail' => $this->createFailingRequestLocation(), 'json' => $customLocation]
+        );
+
+        $this->triggerFailedSerialization($serializer);
+        $request = $serializer(new Command('Next', ['public' => 'ok']));
+
+        $this->assertSame('public', $request->getHeaderLine('X-Custom-Request-Location'));
+        $this->assertSame('', (string) $request->getBody());
+    }
+
+    private function serializeAfterFailure($statefulLocation)
+    {
+        $serializer = new Serializer(
+            $this->createFailedSerializationDescription($statefulLocation),
+            ['fail' => $this->createFailingRequestLocation()]
+        );
+
+        $this->triggerFailedSerialization($serializer);
+
+        return $serializer(new Command('Next', ['public' => 'ok']));
+    }
+
+    private function triggerFailedSerialization(Serializer $serializer)
+    {
+        try {
+            $serializer(new Command('Fail', [
+                'secret' => 'TOPSECRET',
+                'break' => true,
+            ]));
+            $this->fail('Expected request serialization to fail.');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertSame('Synthetic request location failure.', $e->getMessage());
+        }
+    }
+
+    private function createFailedSerializationDescription($statefulLocation)
+    {
+        return new Description([
+            'baseUri' => 'https://example.test',
+            'operations' => [
+                'Fail' => [
+                    'httpMethod' => 'POST',
+                    'uri' => '/fail',
+                    'parameters' => [
+                        'secret' => ['type' => 'string', 'location' => $statefulLocation],
+                        'break' => ['type' => 'boolean', 'location' => 'fail'],
+                    ],
+                ],
+                'Next' => [
+                    'httpMethod' => 'POST',
+                    'uri' => '/next',
+                    'parameters' => [
+                        'public' => ['type' => 'string', 'location' => $statefulLocation],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    private function createFailingRequestLocation()
+    {
+        return new class implements RequestLocationInterface {
+            public function visit(
+                CommandInterface $command,
+                RequestInterface $request,
+                Parameter $param
+            ) {
+                throw new \InvalidArgumentException('Synthetic request location failure.');
+            }
+
+            public function after(
+                CommandInterface $command,
+                RequestInterface $request,
+                Operation $operation
+            ) {
+                return $request;
+            }
+        };
     }
 }


### PR DESCRIPTION
This changes the serializer so built-in request locations are no longer shared through a static default cache, and so built-in request-location state is reset after failed request serialization. Custom request locations are still preserved and continue to take precedence over the defaults.\n\nThis fixes cases where a stateful built-in location, such as JSON, XML, form parameters, or multipart, could buffer request data before another location failed and then leak that buffered state into a later serialization in the same PHP process. The change does not alter successful request output.\n\nI verified this with the targeted serializer and request-location PHPUnit tests, the full PHPUnit suite, a Dockerized PHP 7.4 Composer update, and Dockerized PHPStan with an increased memory limit.