### PR TITLE
Fix schema validation edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Harden request serialization state after failures
 * Preserve explicit `null` JSON response properties
+* Validate `ToArrayInterface` object properties after conversion
+* Enforce zero-valued schema validation bounds
 
 ## 1.5.2 - 2026-05-22
 

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -409,7 +409,7 @@ class Parameter implements ToArrayInterface
     /**
      * Get the minimum allowed length of a string value
      *
-     * @return int
+     * @return int|null
      */
     public function getMinLength()
     {
@@ -439,7 +439,7 @@ class Parameter implements ToArrayInterface
     /**
      * Get the minimum allowed number of items in an array value
      *
-     * @return int
+     * @return int|null
      */
     public function getMinItems()
     {

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -138,6 +138,7 @@ class SchemaValidator
             // Convert the value to an array
             if (!$valueIsArray && $value instanceof ToArrayInterface) {
                 $value = $value->toArray();
+                $valueIsArray = true;
             }
 
             if ($valueIsArray) {
@@ -257,35 +258,35 @@ class SchemaValidator
             }
 
             $strLen = null;
-            if ($min = $param->getMinLength()) {
+            if (null !== ($min = $param->getMinLength())) {
                 $strLen = strlen($value);
                 if ($strLen < $min) {
                     $this->errors[] = "{$path} length must be greater than or equal to {$min}";
                 }
             }
-            if ($max = $param->getMaxLength()) {
-                if (($strLen ?: strlen($value)) > $max) {
+            if (null !== ($max = $param->getMaxLength())) {
+                if (($strLen !== null ? $strLen : strlen($value)) > $max) {
                     $this->errors[] = "{$path} length must be less than or equal to {$max}";
                 }
             }
         } elseif ($type == 'array') {
             $size = null;
-            if ($min = $param->getMinItems()) {
+            if (null !== ($min = $param->getMinItems())) {
                 $size = count($value);
                 if ($size < $min) {
                     $this->errors[] = "{$path} must contain {$min} or more elements";
                 }
             }
-            if ($max = $param->getMaxItems()) {
-                if (($size ?: count($value)) > $max) {
+            if (null !== ($max = $param->getMaxItems())) {
+                if (($size !== null ? $size : count($value)) > $max) {
                     $this->errors[] = "{$path} must contain {$max} or fewer elements";
                 }
             }
         } elseif ($type == 'integer' || $type == 'number' || $type == 'numeric') {
-            if (($min = $param->getMinimum()) && $value < $min) {
+            if (null !== ($min = $param->getMinimum()) && $value < $min) {
                 $this->errors[] = "{$path} must be greater than or equal to {$min}";
             }
-            if (($max = $param->getMaximum()) && $value > $max) {
+            if (null !== ($max = $param->getMaximum()) && $value > $max) {
                 $this->errors[] = "{$path} must be less than or equal to {$max}";
             }
         }

--- a/tests/SchemaValidatorTest.php
+++ b/tests/SchemaValidatorTest.php
@@ -102,6 +102,72 @@ class SchemaValidatorTest extends TestCase
         $this->assertTrue($this->validator->validate($p, $o));
     }
 
+    public function testValidatesToArrayInterfacePropertiesAfterConversion()
+    {
+        $o = $this->getMockBuilder(ToArrayInterface::class)
+            ->setMethods(['toArray'])
+            ->getMockForAbstractClass();
+        $o->expects($this->once())
+            ->method('toArray')
+            ->will($this->returnValue([]));
+        $p = new Parameter([
+            'name' => 'test',
+            'type' => 'object',
+            'properties' => [
+                'foo' => ['type' => 'string', 'required' => true],
+            ],
+        ]);
+
+        $this->assertFalse($this->validator->validate($p, $o));
+        $this->assertEquals(['[test][foo] is a required string'], $this->validator->getErrors());
+    }
+
+    public function testValidatesZeroNumberBounds()
+    {
+        $minimum = new Parameter([
+            'name' => 'test',
+            'type' => 'integer',
+            'minimum' => 0,
+        ]);
+        $minimumValue = -1;
+
+        $this->assertFalse($this->validator->validate($minimum, $minimumValue));
+        $this->assertEquals(['[test] must be greater than or equal to 0'], $this->validator->getErrors());
+
+        $maximum = new Parameter([
+            'name' => 'test',
+            'type' => 'integer',
+            'maximum' => 0,
+        ]);
+        $maximumValue = 1;
+
+        $this->assertFalse($this->validator->validate($maximum, $maximumValue));
+        $this->assertEquals(['[test] must be less than or equal to 0'], $this->validator->getErrors());
+    }
+
+    public function testValidatesZeroCollectionBounds()
+    {
+        $string = new Parameter([
+            'name' => 'test',
+            'type' => 'string',
+            'maxLength' => 0,
+        ]);
+        $stringValue = 'a';
+
+        $this->assertFalse($this->validator->validate($string, $stringValue));
+        $this->assertEquals(['[test] length must be less than or equal to 0'], $this->validator->getErrors());
+
+        $array = new Parameter([
+            'name' => 'test',
+            'type' => 'array',
+            'maxItems' => 0,
+        ]);
+        $arrayValue = ['a'];
+
+        $this->assertFalse($this->validator->validate($array, $arrayValue));
+        $this->assertEquals(['[test] must contain 0 or fewer elements'], $this->validator->getErrors());
+    }
+
     public function testMergesValidationErrorsInPropertiesWithParent()
     {
         $p = new Parameter([


### PR DESCRIPTION
Backport of #232 to 1.5.\n\nThis fixes schema validation for ToArrayInterface object inputs and zero-valued validation bounds so documented constraints are enforced consistently.\n\nAdded to the change log under 1.5.3 - Upcoming.