### PR TITLE
Prevent XML CDATA injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.5.4 - Upcoming
+
+* Prevent XML CDATA injection during request serialization (GHSA-q8r6-5hfw-5jff)
+
 ## 1.5.3 - 2026-06-02
 
 * Harden request serialization state after failures

--- a/src/RequestLocation/XmlLocation.php
+++ b/src/RequestLocation/XmlLocation.php
@@ -217,11 +217,26 @@ class XmlLocation extends AbstractLocation
             $writer->startElement($name);
         }
         if ($value !== null && strpbrk($value, '<>&')) {
-            $writer->writeCData($value);
+            $this->writeSafeCData($writer, $value);
         } else {
             $writer->writeRaw($value);
         }
         $writer->endElement();
+    }
+
+    private function writeSafeCData(\XMLWriter $writer, $value)
+    {
+        $parts = explode(']]>', $value);
+        $last = array_pop($parts);
+
+        foreach ($parts as $part) {
+            $writer->writeCData($part.']]');
+            $writer->writeCData('>');
+        }
+
+        if ($last !== '') {
+            $writer->writeCData($last);
+        }
     }
 
     /**

--- a/src/RequestLocation/XmlLocation.php
+++ b/src/RequestLocation/XmlLocation.php
@@ -224,7 +224,7 @@ class XmlLocation extends AbstractLocation
         $writer->endElement();
     }
 
-    private function writeSafeCData(\XMLWriter $writer, $value)
+    protected function writeSafeCData(\XMLWriter $writer, $value)
     {
         $parts = explode(']]>', $value);
         $last = array_pop($parts);

--- a/tests/RequestLocation/XmlLocationTest.php
+++ b/tests/RequestLocation/XmlLocationTest.php
@@ -524,4 +524,57 @@ class XmlLocationTest extends TestCase
             $this->assertEquals($xml, $body);
         }
     }
+
+    /**
+     * @group RequestLocation
+     */
+    public function testSplitsCDataTerminatorsToPreventXmlInjection()
+    {
+        $payload = 'x]]></Foo><Injected attr="1"/><Foo><![CDATA[y';
+        $document = simplexml_load_string($this->serializeXmlValue($payload));
+
+        $this->assertNotFalse($document);
+        $this->assertCount(1, $document->Foo);
+        $this->assertCount(0, $document->Injected);
+        $this->assertSame($payload, (string) $document->Foo);
+    }
+
+    public function cdataTerminatorProvider()
+    {
+        return [
+            ['a]]>b'],
+            ['abc]]>'],
+            [']]>'],
+        ];
+    }
+
+    /**
+     * @dataProvider cdataTerminatorProvider
+     *
+     * @group RequestLocation
+     */
+    public function testPreservesTextContainingCDataTerminators($value)
+    {
+        $document = simplexml_load_string($this->serializeXmlValue($value));
+
+        $this->assertNotFalse($document);
+        $this->assertSame($value, (string) $document->Foo);
+    }
+
+    private function serializeXmlValue($value)
+    {
+        $location = new XmlLocation();
+        $command = new Command('foo', ['Foo' => $value]);
+        $request = new Request('POST', 'http://httbin.org');
+        $param = new Parameter([
+            'name' => 'Foo',
+            'location' => 'xml',
+            'type' => 'string',
+        ]);
+
+        $location->visit($command, $request, $param);
+        $request = $location->after($command, $request, new Operation());
+
+        return (string) $request->getBody();
+    }
 }


### PR DESCRIPTION
This fixes XML request serialization so scalar element values containing CDATA terminators remain inside the intended text node. The serializer now splits embedded CDATA terminators across adjacent CDATA sections, preserving the original value while preventing injected XML nodes from escaping the modeled element.