### PR TITLE
Reject scalar JSON response bodies

### DIFF
--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -32,8 +32,7 @@ class JsonLocation extends AbstractLocation
         Parameter $model
     ): ResultInterface {
         $body = (string) $response->getBody();
-        $body = $body ?: '{}';
-        $decoded = Utils::jsonDecode($body, true);
+        $decoded = $body !== '' ? Utils::jsonDecode($body, true) : [];
         if (!is_array($decoded)) {
             throw new \RuntimeException('JSON response body must be an object or array');
         }

--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -33,11 +33,13 @@ class JsonLocation extends AbstractLocation
     ): ResultInterface {
         $body = (string) $response->getBody();
         $decoded = $body !== '' ? Utils::jsonDecode($body, true) : [];
+
         if (!is_array($decoded)) {
             throw new \RuntimeException('JSON response body must be an object or array');
         }
 
         $this->json = $decoded;
+
         // relocate named arrays, so that they have the same structure as
         //  arrays nested in objects and visit can work on them in the same way
         if ($model->getType() === 'array' && ($name = $model->getName())) {

--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -33,7 +33,12 @@ class JsonLocation extends AbstractLocation
     ): ResultInterface {
         $body = (string) $response->getBody();
         $body = $body ?: '{}';
-        $this->json = Utils::jsonDecode($body, true);
+        $decoded = Utils::jsonDecode($body, true);
+        if (!is_array($decoded)) {
+            throw new \RuntimeException('JSON response body must be an object or array');
+        }
+
+        $this->json = $decoded;
         // relocate named arrays, so that they have the same structure as
         //  arrays nested in objects and visit can work on them in the same way
         if ($model->getType() === 'array' && ($name = $model->getName())) {

--- a/tests/ResponseLocation/JsonLocationTest.php
+++ b/tests/ResponseLocation/JsonLocationTest.php
@@ -125,6 +125,7 @@ class JsonLocationTest extends TestCase
     {
         return [
             ['null'],
+            ['0'],
             ['123'],
             ['"x"'],
             ['true'],

--- a/tests/ResponseLocation/JsonLocationTest.php
+++ b/tests/ResponseLocation/JsonLocationTest.php
@@ -121,6 +121,31 @@ class JsonLocationTest extends TestCase
         $this->assertEquals([], $result->toArray());
     }
 
+    public static function scalarJsonResponseBodyProvider(): array
+    {
+        return [
+            ['null'],
+            ['123'],
+            ['"x"'],
+            ['true'],
+        ];
+    }
+
+    /**
+     * @dataProvider scalarJsonResponseBodyProvider
+     *
+     * @group ResponseLocation
+     */
+    public function testRejectsScalarJsonResponseBodies(string $body): void
+    {
+        $location = new JsonLocation();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('JSON response body must be an object or array');
+
+        $location->before(new Result(), new Response(200, [], $body), new Parameter());
+    }
+
     public static function jsonProvider(): array
     {
         return [


### PR DESCRIPTION
This makes JSON response processing reject top-level scalar JSON bodies with a catchable runtime exception instead of allowing typed internal state assignment to fail.