### PR TITLE
Use XMLWriter text serialization for XML request values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Require custom implementations and subclasses of public service APIs to match native method signatures
 * Require custom parameter filters and extension points to accept exact value types instead of relying on scalar coercion
 * Limit XML response traversal and additional-property conversion to 512 nested elements by default
+* Serialize XML request scalar element text with XMLWriter text escaping instead of CDATA sections
 * Honor the documented `GuzzleClient` `response_locations` option when building the default deserializer
 * Require `null` schema types to match only `null` values
 * Improve PHPDoc for service client transformers, command handler stacks, and service description, operation, and parameter schema arrays

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -142,6 +142,13 @@ explicitly:
 ['type' => ['null', 'boolean']]
 ```
 
+#### XML Request Text Serialization
+
+XML request scalar element values containing `<`, `>`, or `&` are now
+serialized as escaped text instead of CDATA sections. XML parsers see the same
+text value, but applications or tests that compare raw XML request bodies may
+need to update expected strings.
+
 #### XML Response Depth Limit
 
 XML response deserialization now rejects XML responses that exceed 512 nested

--- a/src/RequestLocation/XmlLocation.php
+++ b/src/RequestLocation/XmlLocation.php
@@ -228,27 +228,8 @@ class XmlLocation extends AbstractLocation
         } else {
             $writer->startElement($name);
         }
-        if ($value !== '' && strpbrk($value, '<>&')) {
-            $this->writeSafeCData($writer, $value);
-        } else {
-            $writer->writeRaw($value);
-        }
+        $writer->text($value);
         $writer->endElement();
-    }
-
-    protected function writeSafeCData(\XMLWriter $writer, string $value): void
-    {
-        $parts = explode(']]>', $value);
-        $last = array_pop($parts);
-
-        foreach ($parts as $part) {
-            $writer->writeCData($part.']]');
-            $writer->writeCData('>');
-        }
-
-        if ($last !== '') {
-            $writer->writeCData($last);
-        }
     }
 
     /**

--- a/tests/RequestLocation/XmlLocationTest.php
+++ b/tests/RequestLocation/XmlLocationTest.php
@@ -388,7 +388,7 @@ class XmlLocationTest extends TestCase
                     ],
                 ],
                 ['Foo' => '<h1>This is a title</h1>'],
-                '<Request><Foo xmlns="http://foo.com"><![CDATA[<h1>This is a title</h1>]]></Foo></Request>',
+                '<Request><Foo xmlns="http://foo.com">&lt;h1&gt;This is a title&lt;/h1&gt;</Foo></Request>',
             ],
             // Flat array at top level
             [
@@ -528,7 +528,7 @@ class XmlLocationTest extends TestCase
     /**
      * @group RequestLocation
      */
-    public function testSplitsCDataTerminatorsToPreventXmlInjection(): void
+    public function testSerializesCDataTerminatorsAsTextWithoutXmlInjection(): void
     {
         $payload = 'x]]></Foo><Injected attr="1"/><Foo><![CDATA[y';
         $document = simplexml_load_string($this->serializeXmlValue($payload));


### PR DESCRIPTION
This updates XML request serialization on 2.0 to write scalar element values as escaped XML text instead of generating CDATA sections, preserving parsed text while simplifying the serializer and avoiding CDATA-specific edge cases.