### PR TITLE
Allow null header location values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.6.1 - Upcoming
+
+* Allow deprecated `null` header location values to normalize to empty strings
+
 ## 1.6.0 - 2026-06-02
 
 * Require `guzzlehttp/guzzle` ^7.11 and `guzzlehttp/psr7` ^2.11

--- a/src/RequestLocation/HeaderLocation.php
+++ b/src/RequestLocation/HeaderLocation.php
@@ -77,18 +77,7 @@ class HeaderLocation extends AbstractLocation
             return $value;
         }
 
-        if ($value === null) {
-            \trigger_deprecation(
-                'guzzlehttp/guzzle-services',
-                '1.6',
-                'Passing %s as a header location value is deprecated; guzzlehttp/guzzle-services 2.0 requires string|string[].',
-                get_debug_type($value)
-            );
-
-            return '';
-        }
-
-        if (is_scalar($value)) {
+        if (is_scalar($value) || $value === null) {
             \trigger_deprecation(
                 'guzzlehttp/guzzle-services',
                 '1.6',
@@ -115,7 +104,7 @@ class HeaderLocation extends AbstractLocation
                     continue;
                 }
 
-                if ($item === null) {
+                if (is_scalar($item) || $item === null) {
                     \trigger_deprecation(
                         'guzzlehttp/guzzle-services',
                         '1.6',
@@ -123,23 +112,12 @@ class HeaderLocation extends AbstractLocation
                         get_debug_type($item)
                     );
 
-                    $value[$key] = '';
+                    $value[$key] = (string) $item;
 
                     continue;
                 }
 
-                if (!is_scalar($item)) {
-                    throw new \InvalidArgumentException('Header location values must be scalar or an array of scalars.');
-                }
-
-                \trigger_deprecation(
-                    'guzzlehttp/guzzle-services',
-                    '1.6',
-                    'Passing %s inside a header location value array is deprecated; guzzlehttp/guzzle-services 2.0 requires string|string[].',
-                    get_debug_type($item)
-                );
-
-                $value[$key] = (string) $item;
+                throw new \InvalidArgumentException('Header location values must be scalar or an array of scalars.');
             }
 
             return $value;

--- a/src/RequestLocation/HeaderLocation.php
+++ b/src/RequestLocation/HeaderLocation.php
@@ -77,6 +77,17 @@ class HeaderLocation extends AbstractLocation
             return $value;
         }
 
+        if ($value === null) {
+            \trigger_deprecation(
+                'guzzlehttp/guzzle-services',
+                '1.6',
+                'Passing %s as a header location value is deprecated; guzzlehttp/guzzle-services 2.0 requires string|string[].',
+                get_debug_type($value)
+            );
+
+            return '';
+        }
+
         if (is_scalar($value)) {
             \trigger_deprecation(
                 'guzzlehttp/guzzle-services',
@@ -101,6 +112,19 @@ class HeaderLocation extends AbstractLocation
 
             foreach ($value as $key => $item) {
                 if (is_string($item)) {
+                    continue;
+                }
+
+                if ($item === null) {
+                    \trigger_deprecation(
+                        'guzzlehttp/guzzle-services',
+                        '1.6',
+                        'Passing %s inside a header location value array is deprecated; guzzlehttp/guzzle-services 2.0 requires string|string[].',
+                        get_debug_type($item)
+                    );
+
+                    $value[$key] = '';
+
                     continue;
                 }
 

--- a/tests/RequestLocation/HeaderLocationTest.php
+++ b/tests/RequestLocation/HeaderLocationTest.php
@@ -52,7 +52,7 @@ class HeaderLocationTest extends TestCase
     public function testVisitsLocationRejectsInvalidHeaderValue()
     {
         $location = new HeaderLocation('header');
-        $command = new Command('foo', ['foo' => null]);
+        $command = new Command('foo', ['foo' => new \stdClass()]);
         $request = new Request('POST', 'http://httbin.org');
         $param = new Parameter(['name' => 'foo']);
 
@@ -68,7 +68,7 @@ class HeaderLocationTest extends TestCase
     public function testVisitsLocationRejectsInvalidArrayHeaderValue()
     {
         $location = new HeaderLocation('header');
-        $command = new Command('foo', ['foo' => ['bar', null]]);
+        $command = new Command('foo', ['foo' => ['bar', new \stdClass()]]);
         $request = new Request('POST', 'http://httbin.org');
         $param = new Parameter(['name' => 'foo']);
 
@@ -106,7 +106,7 @@ class HeaderLocationTest extends TestCase
     {
         $location = new HeaderLocation('header');
         $command = new Command('foo', ['foo' => 'bar']);
-        $command['add'] = null;
+        $command['add'] = new \stdClass();
         $operation = new Operation([
             'additionalParameters' => [
                 'location' => 'header',


### PR DESCRIPTION
Restores the previous behavior where header location values set to null are accepted, deprecated, and normalized to an empty string instead of rejected.