### PR TITLE
Remove stale process TODO

### DIFF
--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -173,11 +173,5 @@ class GuzzleClient extends ServiceClient
         if (!isset($config['validate']) || $config['validate'] === true) {
             $stack->push(new ValidatedDescriptionHandler($this->description), 'validate_description');
         }
-
-        if (!isset($config['process']) || $config['process'] === true) {
-            // TODO: This belongs to the Deserializer and should be handled there.
-            // Question: What is the result when the Deserializer is bypassed?
-            // Possible answer: The raw response in the command result.
-        }
     }
 }


### PR DESCRIPTION
This removes a stale no-op process block from GuzzleClient::processConfig. Response processing is already handled when the default deserializer is constructed and when the deserializer decides whether to return the raw response.