### PR TITLE
Deprecate invalid GuzzleClient config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.7.0 - Upcoming
+
+* Deprecate invalid `GuzzleClient` configuration option values
+
 ## 1.6.1 - 2026-06-04
 
 * Allow deprecated `null` header location values to normalize to empty strings

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -5,6 +5,7 @@ namespace GuzzleHttp\Command\Guzzle;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\Guzzle\Handler\ValidatedDescriptionHandler;
+use GuzzleHttp\Command\Guzzle\ResponseLocation\ResponseLocationInterface;
 use GuzzleHttp\Command\ServiceClient;
 use GuzzleHttp\HandlerStack;
 
@@ -46,6 +47,8 @@ class GuzzleClient extends ServiceClient
         ?HandlerStack $commandHandlerStack = null,
         array $config = []
     ) {
+        self::deprecateInvalidConfigOptionTypes($config);
+
         $this->config = $config;
         $this->description = $description;
         $serializer = $this->getSerializer($commandToRequestTransformer);
@@ -137,7 +140,78 @@ class GuzzleClient extends ServiceClient
 
     public function setConfig($option, $value)
     {
+        if (is_int($option) || is_string($option)) {
+            self::deprecateInvalidConfigOptionValue((string) $option, $value);
+        }
+
         $this->config[$option] = $value;
+    }
+
+    /**
+     * @return void
+     */
+    private static function deprecateInvalidConfigOptionTypes(array $config)
+    {
+        foreach ($config as $option => $value) {
+            self::deprecateInvalidConfigOptionValue((string) $option, $value);
+        }
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return void
+     */
+    private static function deprecateInvalidConfigOptionValue(string $option, $value)
+    {
+        if ($option === 'defaults' && !is_array($value)) {
+            self::deprecateInvalidConfigOptionType($option, 'array', $value);
+
+            return;
+        }
+
+        if (($option === 'validate' || $option === 'process') && !is_bool($value)) {
+            self::deprecateInvalidConfigOptionType($option, 'bool', $value);
+
+            return;
+        }
+
+        if ($option !== 'response_locations') {
+            return;
+        }
+
+        if (!is_array($value)) {
+            self::deprecateInvalidConfigOptionType($option, 'array', $value);
+
+            return;
+        }
+
+        foreach ($value as $name => $location) {
+            if (!$location instanceof ResponseLocationInterface) {
+                self::deprecateInvalidConfigOptionType(
+                    $option.'.'.(string) $name,
+                    ResponseLocationInterface::class,
+                    $location
+                );
+            }
+        }
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return void
+     */
+    private static function deprecateInvalidConfigOptionType(string $option, string $expected, $value)
+    {
+        \trigger_deprecation(
+            'guzzlehttp/guzzle-services',
+            '1.7',
+            'Passing %s to GuzzleClient config option "%s" is deprecated; guzzlehttp/guzzle-services 2.0 requires %s.',
+            get_debug_type($value),
+            $option,
+            $expected
+        );
     }
 
     /**


### PR DESCRIPTION
This deprecates invalid documented GuzzleClient configuration option values while preserving existing 1.x behavior. These warnings prepare applications for guzzlehttp/guzzle-services 2.0, where the same invalid configuration values can be rejected consistently.