### PR TITLE
Reject invalid GuzzleClient config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Limit XML response traversal and additional-property conversion to 512 nested elements by default
 * Serialize XML request scalar element text with XMLWriter text escaping instead of CDATA sections
 * Honor the documented `GuzzleClient` `response_locations` option when building the default deserializer
+* Reject invalid `GuzzleClient` configuration option values
 * Require `null` schema types to match only `null` values
 * Improve PHPDoc for service client transformers, command handler stacks, and service description, operation, and parameter schema arrays
 * Mark `Operation`, `ValidatedDescriptionHandler`, and `Rfc3986Serializer` as soft-final with `@final` annotations

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "guzzlehttp/command": "^2.0@dev",
         "guzzlehttp/guzzle": "^8.0@dev",
         "guzzlehttp/psr7": "^3.0@dev",
-        "guzzlehttp/uri-template": "^2.0@dev"
+        "guzzlehttp/uri-template": "^2.0@dev",
+        "symfony/polyfill-php80": "^1.24"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -67,7 +67,7 @@ class GuzzleClient extends ServiceClient
         ?HandlerStack $commandHandlerStack = null,
         array $config = []
     ) {
-        self::deprecateInvalidConfigOptionTypes($config);
+        self::assertConfigOptionTypes($config);
 
         $this->config = $config;
         $this->description = $description;
@@ -155,7 +155,7 @@ class GuzzleClient extends ServiceClient
     public function setConfig($option, $value): void
     {
         if (is_int($option) || is_string($option)) {
-            self::deprecateInvalidConfigOptionValue((string) $option, $value);
+            self::assertConfigOptionType((string) $option, $value);
         }
 
         $this->config[$option] = $value;
@@ -164,10 +164,10 @@ class GuzzleClient extends ServiceClient
     /**
      * @return void
      */
-    private static function deprecateInvalidConfigOptionTypes(array $config)
+    private static function assertConfigOptionTypes(array $config)
     {
         foreach ($config as $option => $value) {
-            self::deprecateInvalidConfigOptionValue((string) $option, $value);
+            self::assertConfigOptionType((string) $option, $value);
         }
     }
 
@@ -176,16 +176,16 @@ class GuzzleClient extends ServiceClient
      *
      * @return void
      */
-    private static function deprecateInvalidConfigOptionValue(string $option, $value)
+    private static function assertConfigOptionType(string $option, $value)
     {
         if ($option === 'defaults' && !is_array($value)) {
-            self::deprecateInvalidConfigOptionType($option, 'array', $value);
+            self::invalidConfigOptionType($option, 'array', $value);
 
             return;
         }
 
         if (($option === 'validate' || $option === 'process') && !is_bool($value)) {
-            self::deprecateInvalidConfigOptionType($option, 'bool', $value);
+            self::invalidConfigOptionType($option, 'bool', $value);
 
             return;
         }
@@ -195,14 +195,14 @@ class GuzzleClient extends ServiceClient
         }
 
         if (!is_array($value)) {
-            self::deprecateInvalidConfigOptionType($option, 'array', $value);
+            self::invalidConfigOptionType($option, 'array', $value);
 
             return;
         }
 
         foreach ($value as $name => $location) {
             if (!$location instanceof ResponseLocationInterface) {
-                self::deprecateInvalidConfigOptionType(
+                self::invalidConfigOptionType(
                     $option.'.'.(string) $name,
                     ResponseLocationInterface::class,
                     $location
@@ -216,16 +216,14 @@ class GuzzleClient extends ServiceClient
      *
      * @return void
      */
-    private static function deprecateInvalidConfigOptionType(string $option, string $expected, $value)
+    private static function invalidConfigOptionType(string $option, string $expected, $value)
     {
-        \trigger_deprecation(
-            'guzzlehttp/guzzle-services',
-            '1.7',
-            'Passing %s to GuzzleClient config option "%s" is deprecated; guzzlehttp/guzzle-services 2.0 requires %s.',
+        throw new \InvalidArgumentException(\sprintf(
+            'Passing %s to GuzzleClient config option "%s" is invalid; expected %s.',
             get_debug_type($value),
             $option,
             $expected
-        );
+        ));
     }
 
     /**

--- a/tests/GuzzleClientTest.php
+++ b/tests/GuzzleClientTest.php
@@ -251,6 +251,69 @@ class GuzzleClientTest extends TestCase
         $this->assertEquals('listen', $guzzle->getConfig('abc'));
     }
 
+    /**
+     * @dataProvider invalidConfigProvider
+     */
+    public function testRejectsInvalidConfigOptions(array $config, string $expectedMessage): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        new GuzzleClient(
+            new HttpClient(),
+            new Description([]),
+            $this->commandToRequestTransformer(),
+            $this->responseToResultTransformer(),
+            null,
+            $config
+        );
+    }
+
+    public static function invalidConfigProvider(): iterable
+    {
+        yield 'defaults' => [
+            ['defaults' => 'invalid'],
+            'Passing string to GuzzleClient config option "defaults" is invalid; expected array.',
+        ];
+
+        yield 'validate' => [
+            ['validate' => 'true'],
+            'Passing string to GuzzleClient config option "validate" is invalid; expected bool.',
+        ];
+
+        yield 'process' => [
+            ['process' => 'false'],
+            'Passing string to GuzzleClient config option "process" is invalid; expected bool.',
+        ];
+
+        yield 'response_locations' => [
+            ['response_locations' => 'json'],
+            'Passing string to GuzzleClient config option "response_locations" is invalid; expected array.',
+        ];
+
+        yield 'response_locations value' => [
+            ['response_locations' => ['json' => new \stdClass()]],
+            'Passing stdClass to GuzzleClient config option "response_locations.json" is invalid; expected GuzzleHttp\Command\Guzzle\ResponseLocation\ResponseLocationInterface.',
+        ];
+    }
+
+    public function testRejectsInvalidConfigOptionSetAfterConstruction(): void
+    {
+        $guzzle = new GuzzleClient(
+            new HttpClient(),
+            new Description([]),
+            $this->commandToRequestTransformer(),
+            $this->responseToResultTransformer(),
+            null,
+            ['validate' => false, 'process' => false]
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Passing string to GuzzleClient config option "process" is invalid; expected bool.');
+
+        $guzzle->setConfig('process', 'false');
+    }
+
     public function testGetCommandUsesExactOperationName(): void
     {
         $guzzle = new GuzzleClient(


### PR DESCRIPTION
This converts the GuzzleClient configuration value deprecations from 1.7 into exceptions on the 2.0 branch. It also adds a direct PHP 8.0 polyfill requirement because the validation messages use get_debug_type while 2.0 still supports PHP 7.4.