### PR TITLE
Use debug type for operation parameters

### DIFF
--- a/src/Operation.php
+++ b/src/Operation.php
@@ -296,9 +296,12 @@ class Operation implements ToArrayInterface
         // Parameters need special handling when adding
         foreach ($this->config['parameters'] as $name => $param) {
             if (!is_array($param)) {
-                throw new \InvalidArgumentException(
-                    "Parameters must be arrays, {$this->config['name']}.$name is ".get_debug_type($param)
-                );
+                throw new \InvalidArgumentException(\sprintf(
+                    'Passing %s as operation parameter "%s.%s" is invalid; expected array.',
+                    get_debug_type($param),
+                    $this->config['name'],
+                    $name
+                ));
             }
             $param['name'] = $name;
             $this->parameters[$name] = new Parameter(

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -297,7 +297,7 @@ class Operation implements ToArrayInterface
         foreach ($this->config['parameters'] as $name => $param) {
             if (!is_array($param)) {
                 throw new \InvalidArgumentException(
-                    "Parameters must be arrays, {$this->config['name']}.$name is ".gettype($param)
+                    "Parameters must be arrays, {$this->config['name']}.$name is ".get_debug_type($param)
                 );
             }
             $param['name'] = $name;

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -193,7 +193,7 @@ class OperationTest extends TestCase
 
     public function testEnsuresParametersAreArrays(): void
     {
-        $this->expectExceptionMessage('Parameters must be arrays, test.foo is bool');
+        $this->expectExceptionMessage('Passing bool as operation parameter "test.foo" is invalid; expected array.');
         $this->expectException(\InvalidArgumentException::class);
         new Operation(['name' => 'test', 'parameters' => ['foo' => true]]);
     }

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -193,9 +193,9 @@ class OperationTest extends TestCase
 
     public function testEnsuresParametersAreArrays(): void
     {
-        $this->expectExceptionMessage('Parameters must be arrays');
+        $this->expectExceptionMessage('Parameters must be arrays, test.foo is bool');
         $this->expectException(\InvalidArgumentException::class);
-        new Operation(['parameters' => ['foo' => true]]);
+        new Operation(['name' => 'test', 'parameters' => ['foo' => true]]);
     }
 
     public function testHasDescription(): void


### PR DESCRIPTION
This updates the invalid operation parameter definition error to use get_debug_type. That keeps the diagnostic consistent with the other Guzzle 2.0 configuration validation messages while preserving the existing validation behavior.