### PR TITLE
Reject native PHP serialization of runtime pipeline objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Require `guzzlehttp/command` ^2.0 and `guzzlehttp/uri-template` ^2.0
 * Remove the legacy `baseUrl` service description option; use `baseUri` instead
 * Remove the legacy `responseClass` operation option; use `responseModel` instead
+* Reject native PHP serialization of runtime client pipeline objects
 * Default operations without an `httpMethod` to `GET`, preserve explicit `httpMethod` casing, and reject invalid `httpMethod` values
 * Require header location values to be strings or non-empty arrays of strings
 * Return raw PSR-7 responses in the `response` result key when the `process` client option is `false`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -28,12 +28,6 @@ If your application still supports PHP 7.2 or 7.3, or still uses the Guzzle 7
 dependency stack, continue using Guzzle Services 1.x until your minimum PHP and
 dependency versions are raised.
 
-#### Native PHP Serialization Of Runtime Objects
-
-`GuzzleClient`, `ValidatedDescriptionHandler`, `Serializer`, and `Deserializer`
-no longer support native PHP `serialize()` or `unserialize()`. Persist service
-description arrays or configuration instead of runtime pipeline objects.
-
 #### Legacy Service Description Aliases
 
 The legacy `baseUrl` service description option has been removed. Use `baseUri`
@@ -303,6 +297,12 @@ URI templates, request hosts, or unsupported query data may now fail earlier.
 
 Guzzle URI Template 2.x drops PHP 7.2 and 7.3 support. URI template expansion is
 otherwise expected to remain compatible with 1.x.
+
+#### Native PHP Serialization of Runtime Objects
+
+`GuzzleClient`, `ValidatedDescriptionHandler`, `Serializer`, and `Deserializer`
+no longer support native PHP `serialize()` or `unserialize()`. Persist service
+description arrays or configuration instead of runtime pipeline objects.
 
 1.0 from 0.6
 ------------

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -28,6 +28,12 @@ If your application still supports PHP 7.2 or 7.3, or still uses the Guzzle 7
 dependency stack, continue using Guzzle Services 1.x until your minimum PHP and
 dependency versions are raised.
 
+#### Native PHP Serialization Of Runtime Objects
+
+`GuzzleClient`, `ValidatedDescriptionHandler`, `Serializer`, and `Deserializer`
+no longer support native PHP `serialize()` or `unserialize()`. Persist service
+description arrays or configuration instead of runtime pipeline objects.
+
 #### Legacy Service Description Aliases
 
 The legacy `baseUrl` service description option has been removed. Use `baseUri`

--- a/src/Deserializer.php
+++ b/src/Deserializer.php
@@ -32,6 +32,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 class Deserializer
 {
+    use NonSerializableTrait;
+
     /** @var ResponseLocationInterface[] */
     private array $responseLocations;
 

--- a/src/Handler/ValidatedDescriptionHandler.php
+++ b/src/Handler/ValidatedDescriptionHandler.php
@@ -7,6 +7,7 @@ namespace GuzzleHttp\Command\Guzzle\Handler;
 use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\Exception\CommandException;
 use GuzzleHttp\Command\Guzzle\DescriptionInterface;
+use GuzzleHttp\Command\Guzzle\NonSerializableTrait;
 use GuzzleHttp\Command\Guzzle\SchemaValidator;
 use GuzzleHttp\Command\ResultInterface;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -20,6 +21,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  */
 class ValidatedDescriptionHandler
 {
+    use NonSerializableTrait;
+
     private SchemaValidator $validator;
 
     private DescriptionInterface $description;

--- a/src/NonSerializableTrait.php
+++ b/src/NonSerializableTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Command\Guzzle;
+
+/**
+ * @internal
+ */
+trait NonSerializableTrait
+{
+    public function __serialize(): array
+    {
+        throw new \LogicException(static::class.' should never be serialized');
+    }
+
+    public function __unserialize(array $data): void
+    {
+        throw new \LogicException(static::class.' should never be unserialized');
+    }
+}

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -24,6 +24,8 @@ use Psr\Http\Message\RequestInterface;
  */
 class Serializer
 {
+    use NonSerializableTrait;
+
     /** @var RequestLocationInterface[] */
     private array $locations;
 


### PR DESCRIPTION
This rejects native PHP serialization for the runtime client pipeline objects and documents the new behavior. Service description model objects remain unchanged.