### PR TITLE
Fix non-finite float coercion warnings on PHP 8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.6.2 - Upcoming
+
+* Fixed non-finite float values emitting coercion warnings on PHP 8.5
+
 ## 1.6.1 - 2026-06-04
 
 * Allow deprecated `null` header location values to normalize to empty strings

--- a/src/NonFiniteFloats.php
+++ b/src/NonFiniteFloats.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace GuzzleHttp\Command\Guzzle;
+
+/**
+ * Converts non-finite floats to the strings PHP coerces them to, as implicit
+ * coercion of NAN emits a warning on PHP 8.5.
+ *
+ * @internal
+ */
+final class NonFiniteFloats
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    public static function normalize($value)
+    {
+        if (is_float($value) && !is_finite($value)) {
+            return is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array
+     */
+    public static function normalizeAll(array $values)
+    {
+        foreach ($values as $key => $value) {
+            if (is_array($value)) {
+                $values[$key] = self::normalizeAll($value);
+            } else {
+                $values[$key] = self::normalize($value);
+            }
+        }
+
+        return $values;
+    }
+}

--- a/src/QuerySerializer/Rfc3986Serializer.php
+++ b/src/QuerySerializer/Rfc3986Serializer.php
@@ -2,6 +2,8 @@
 
 namespace GuzzleHttp\Command\Guzzle\QuerySerializer;
 
+use GuzzleHttp\Command\Guzzle\NonFiniteFloats;
+
 class Rfc3986Serializer implements QuerySerializerInterface
 {
     /**
@@ -22,7 +24,7 @@ class Rfc3986Serializer implements QuerySerializerInterface
      */
     public function aggregate(array $queryParams)
     {
-        $queryString = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $queryString = http_build_query(NonFiniteFloats::normalizeAll($queryParams), '', '&', PHP_QUERY_RFC3986);
 
         if ($this->removeNumericIndices) {
             $queryString = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $queryString);

--- a/src/RequestLocation/BodyLocation.php
+++ b/src/RequestLocation/BodyLocation.php
@@ -3,6 +3,7 @@
 namespace GuzzleHttp\Command\Guzzle\RequestLocation;
 
 use GuzzleHttp\Command\CommandInterface;
+use GuzzleHttp\Command\Guzzle\NonFiniteFloats;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\MessageInterface;
@@ -34,7 +35,7 @@ class BodyLocation extends AbstractLocation
         $oldValue = $request->getBody()->getContents();
 
         $value = $command[$param->getName()];
-        $value = $param->getName().'='.$param->filter($value);
+        $value = $param->getName().'='.NonFiniteFloats::normalize($param->filter($value));
 
         if ($oldValue !== '') {
             $value = $oldValue.'&'.$value;

--- a/src/RequestLocation/FormParamLocation.php
+++ b/src/RequestLocation/FormParamLocation.php
@@ -3,6 +3,7 @@
 namespace GuzzleHttp\Command\Guzzle\RequestLocation;
 
 use GuzzleHttp\Command\CommandInterface;
+use GuzzleHttp\Command\Guzzle\NonFiniteFloats;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Psr7;
@@ -67,7 +68,7 @@ class FormParamLocation extends AbstractLocation
             }
         }
 
-        $body = http_build_query($data['form_params'], '', '&');
+        $body = http_build_query(NonFiniteFloats::normalizeAll($data['form_params']), '', '&');
         $modify['body'] = Psr7\Utils::streamFor($body);
         $modify['set_headers']['Content-Type'] = $this->contentType;
 

--- a/src/RequestLocation/HeaderLocation.php
+++ b/src/RequestLocation/HeaderLocation.php
@@ -3,6 +3,7 @@
 namespace GuzzleHttp\Command\Guzzle\RequestLocation;
 
 use GuzzleHttp\Command\CommandInterface;
+use GuzzleHttp\Command\Guzzle\NonFiniteFloats;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use Psr\Http\Message\MessageInterface;
@@ -85,7 +86,7 @@ class HeaderLocation extends AbstractLocation
                 get_debug_type($value)
             );
 
-            return (string) $value;
+            return (string) NonFiniteFloats::normalize($value);
         }
 
         if (is_array($value)) {
@@ -112,7 +113,7 @@ class HeaderLocation extends AbstractLocation
                         get_debug_type($item)
                     );
 
-                    $value[$key] = (string) $item;
+                    $value[$key] = (string) NonFiniteFloats::normalize($item);
 
                     continue;
                 }

--- a/src/RequestLocation/XmlLocation.php
+++ b/src/RequestLocation/XmlLocation.php
@@ -3,6 +3,7 @@
 namespace GuzzleHttp\Command\Guzzle\RequestLocation;
 
 use GuzzleHttp\Command\CommandInterface;
+use GuzzleHttp\Command\Guzzle\NonFiniteFloats;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Psr7;
@@ -175,6 +176,7 @@ class XmlLocation extends AbstractLocation
 
             return;
         }
+        $value = NonFiniteFloats::normalize($value);
         if ($param->getData('xmlAttribute')) {
             $this->writeAttribute($writer, $prefix, $name, $namespace, $value);
         } else {

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -175,7 +175,7 @@ class Serializer
                 if (isset($command[$name])) {
                     $variables[$name] = $arg->filter($command[$name]);
                     if (!is_array($variables[$name])) {
-                        $variables[$name] = (string) $variables[$name];
+                        $variables[$name] = (string) NonFiniteFloats::normalize($variables[$name]);
                     }
                 }
             }


### PR DESCRIPTION
PHP 8.5 emits a warning whenever a NAN float is implicitly coerced to a string. The query, form param, header, body, and XML request locations all coerce command values to strings, and the serializer casts URI template variables, so a non-finite float value now triggers the warning at each of these sites. This converts non-finite floats to their string forms explicitly via a small internal helper, preserving the existing output on all PHP versions.