### PR TITLE
Deprecate non-finite float location values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.0 - Upcoming
 
 * Deprecate invalid `GuzzleClient` configuration option values
+* Deprecate non-finite float location values; 2.0 rejects them
 
 ## 1.6.2 - 2026-06-12
 

--- a/src/NonFiniteFloats.php
+++ b/src/NonFiniteFloats.php
@@ -19,9 +19,18 @@ final class NonFiniteFloats
      *
      * @return mixed
      */
-    public static function normalize($value)
+    public static function normalize($value, ?string $context = null)
     {
         if (is_float($value) && !is_finite($value)) {
+            if ($context !== null) {
+                \trigger_deprecation(
+                    'guzzlehttp/guzzle-services',
+                    '1.7',
+                    'Passing a non-finite float as %s is deprecated; guzzlehttp/guzzle-services 2.0 rejects non-finite floats.',
+                    $context
+                );
+            }
+
             return is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
         }
 
@@ -31,13 +40,13 @@ final class NonFiniteFloats
     /**
      * @return array
      */
-    public static function normalizeAll(array $values)
+    public static function normalizeAll(array $values, ?string $context = null)
     {
         foreach ($values as $key => $value) {
             if (is_array($value)) {
-                $values[$key] = self::normalizeAll($value);
+                $values[$key] = self::normalizeAll($value, $context);
             } else {
-                $values[$key] = self::normalize($value);
+                $values[$key] = self::normalize($value, $context);
             }
         }
 

--- a/src/QuerySerializer/Rfc3986Serializer.php
+++ b/src/QuerySerializer/Rfc3986Serializer.php
@@ -24,7 +24,7 @@ class Rfc3986Serializer implements QuerySerializerInterface
      */
     public function aggregate(array $queryParams)
     {
-        $queryString = http_build_query(NonFiniteFloats::normalizeAll($queryParams), '', '&', PHP_QUERY_RFC3986);
+        $queryString = http_build_query(NonFiniteFloats::normalizeAll($queryParams, 'a query location value'), '', '&', PHP_QUERY_RFC3986);
 
         if ($this->removeNumericIndices) {
             $queryString = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $queryString);

--- a/src/RequestLocation/BodyLocation.php
+++ b/src/RequestLocation/BodyLocation.php
@@ -35,7 +35,7 @@ class BodyLocation extends AbstractLocation
         $oldValue = $request->getBody()->getContents();
 
         $value = $command[$param->getName()];
-        $value = $param->getName().'='.NonFiniteFloats::normalize($param->filter($value));
+        $value = $param->getName().'='.NonFiniteFloats::normalize($param->filter($value), 'a body location value');
 
         if ($oldValue !== '') {
             $value = $oldValue.'&'.$value;

--- a/src/RequestLocation/FormParamLocation.php
+++ b/src/RequestLocation/FormParamLocation.php
@@ -68,7 +68,7 @@ class FormParamLocation extends AbstractLocation
             }
         }
 
-        $body = http_build_query(NonFiniteFloats::normalizeAll($data['form_params']), '', '&');
+        $body = http_build_query(NonFiniteFloats::normalizeAll($data['form_params'], 'a formParam location value'), '', '&');
         $modify['body'] = Psr7\Utils::streamFor($body);
         $modify['set_headers']['Content-Type'] = $this->contentType;
 

--- a/src/RequestLocation/XmlLocation.php
+++ b/src/RequestLocation/XmlLocation.php
@@ -176,7 +176,7 @@ class XmlLocation extends AbstractLocation
 
             return;
         }
-        $value = NonFiniteFloats::normalize($value);
+        $value = NonFiniteFloats::normalize($value, 'an xml location value');
         if ($param->getData('xmlAttribute')) {
             $this->writeAttribute($writer, $prefix, $name, $namespace, $value);
         } else {

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -175,7 +175,7 @@ class Serializer
                 if (isset($command[$name])) {
                     $variables[$name] = $arg->filter($command[$name]);
                     if (!is_array($variables[$name])) {
-                        $variables[$name] = (string) NonFiniteFloats::normalize($variables[$name]);
+                        $variables[$name] = (string) NonFiniteFloats::normalize($variables[$name], 'a uri location value');
                     }
                 }
             }


### PR DESCRIPTION
Non-finite float command values in the query, formParam, body, xml, and uri request locations now emit a deprecation, since guzzlehttp/guzzle-services 2.0 rejects them. The values still convert to their usual string forms for now. The header location is unchanged because non-string scalars there already emit a deprecation.