### PR TITLE
Reject non-finite float command values in request locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Reject native PHP serialization of runtime client pipeline objects
 * Default operations without an `httpMethod` to `GET`, preserve explicit `httpMethod` casing, and reject invalid `httpMethod` values
 * Require header location values to be strings or non-empty arrays of strings
+* Reject non-finite float command values in request locations
 * Return raw PSR-7 responses in the `response` result key when the `process` client option is `false`
 * Allow operations to override response processing with the `process` operation option
 * Support JSON response fields with multiple allowed `type` values

--- a/src/NonFiniteFloats.php
+++ b/src/NonFiniteFloats.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Command\Guzzle;
 
 /**
- * Converts non-finite floats to the strings PHP coerces them to, as implicit
- * coercion of NAN emits a warning on PHP 8.5.
+ * Rejects non-finite floats, which the request locations cannot serialize and
+ * which emit coercion warnings on PHP 8.5.
  *
  * @internal
  */
@@ -16,40 +18,22 @@ final class NonFiniteFloats
 
     /**
      * @param mixed $value
-     *
-     * @return mixed
      */
-    public static function normalize($value, ?string $context = null)
+    public static function assertFinite($value, string $context): void
     {
         if (is_float($value) && !is_finite($value)) {
-            if ($context !== null) {
-                \trigger_deprecation(
-                    'guzzlehttp/guzzle-services',
-                    '1.7',
-                    'Passing a non-finite float as %s is deprecated; guzzlehttp/guzzle-services 2.0 rejects non-finite floats.',
-                    $context
-                );
-            }
-
-            return is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+            throw new \InvalidArgumentException(sprintf('Non-finite floats are not supported for %s.', $context));
         }
-
-        return $value;
     }
 
-    /**
-     * @return array
-     */
-    public static function normalizeAll(array $values, ?string $context = null)
+    public static function assertAllFinite(array $values, string $context): void
     {
-        foreach ($values as $key => $value) {
+        foreach ($values as $value) {
             if (is_array($value)) {
-                $values[$key] = self::normalizeAll($value, $context);
+                self::assertAllFinite($value, $context);
             } else {
-                $values[$key] = self::normalize($value, $context);
+                self::assertFinite($value, $context);
             }
         }
-
-        return $values;
     }
 }

--- a/src/QuerySerializer/Rfc3986Serializer.php
+++ b/src/QuerySerializer/Rfc3986Serializer.php
@@ -23,7 +23,8 @@ class Rfc3986Serializer implements QuerySerializerInterface
      */
     public function aggregate(array $queryParams): string
     {
-        $queryString = http_build_query(NonFiniteFloats::normalizeAll($queryParams, 'a query location value'), '', '&', PHP_QUERY_RFC3986);
+        NonFiniteFloats::assertAllFinite($queryParams, 'a query location value');
+        $queryString = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
 
         if ($this->removeNumericIndices) {
             $queryString = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $queryString);

--- a/src/RequestLocation/BodyLocation.php
+++ b/src/RequestLocation/BodyLocation.php
@@ -31,7 +31,9 @@ class BodyLocation extends AbstractLocation
         $oldValue = $request->getBody()->getContents();
 
         $value = $command[$param->getName()];
-        $value = $param->getName().'='.NonFiniteFloats::normalize($param->filter($value), 'a body location value');
+        $filtered = $param->filter($value);
+        NonFiniteFloats::assertFinite($filtered, 'a body location value');
+        $value = $param->getName().'='.$filtered;
 
         if ($oldValue !== '') {
             $value = $oldValue.'&'.$value;

--- a/src/RequestLocation/FormParamLocation.php
+++ b/src/RequestLocation/FormParamLocation.php
@@ -60,7 +60,8 @@ class FormParamLocation extends AbstractLocation
             }
         }
 
-        $body = http_build_query(NonFiniteFloats::normalizeAll($data['form_params'], 'a formParam location value'), '', '&');
+        NonFiniteFloats::assertAllFinite($data['form_params'], 'a formParam location value');
+        $body = http_build_query($data['form_params'], '', '&');
         $modify['body'] = Psr7\Utils::streamFor($body);
         $modify['set_headers']['Content-Type'] = $this->contentType;
 

--- a/src/RequestLocation/HeaderLocation.php
+++ b/src/RequestLocation/HeaderLocation.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace GuzzleHttp\Command\Guzzle\RequestLocation;
 
 use GuzzleHttp\Command\CommandInterface;
-use GuzzleHttp\Command\Guzzle\NonFiniteFloats;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use Psr\Http\Message\RequestInterface;
@@ -61,17 +60,6 @@ class HeaderLocation extends AbstractLocation
             return $value;
         }
 
-        if (is_scalar($value) || $value === null) {
-            \trigger_deprecation(
-                'guzzlehttp/guzzle-services',
-                '1.6',
-                'Passing %s as a header location value is deprecated; guzzlehttp/guzzle-services 2.0 requires string|string[].',
-                get_debug_type($value)
-            );
-
-            return (string) NonFiniteFloats::normalize($value);
-        }
-
         if (is_array($value)) {
             if ($value === []) {
                 throw new \InvalidArgumentException('Header location values must be strings or non-empty arrays of strings.');
@@ -81,21 +69,6 @@ class HeaderLocation extends AbstractLocation
                 if (!is_string($item)) {
                     throw new \InvalidArgumentException('Header location values must be strings or non-empty arrays of strings.');
                 }
-
-                if (is_scalar($item) || $item === null) {
-                    \trigger_deprecation(
-                        'guzzlehttp/guzzle-services',
-                        '1.6',
-                        'Passing %s inside a header location value array is deprecated; guzzlehttp/guzzle-services 2.0 requires string|string[].',
-                        get_debug_type($item)
-                    );
-
-                    $value[$key] = (string) NonFiniteFloats::normalize($item);
-
-                    continue;
-                }
-
-                throw new \InvalidArgumentException('Header location values must be scalar or an array of scalars.');
             }
 
             return $value;

--- a/src/RequestLocation/XmlLocation.php
+++ b/src/RequestLocation/XmlLocation.php
@@ -172,7 +172,7 @@ class XmlLocation extends AbstractLocation
 
             return;
         }
-        $value = NonFiniteFloats::normalize($value, 'an xml location value');
+        NonFiniteFloats::assertFinite($value, 'an xml location value');
         if ($param->getData('xmlAttribute')) {
             $value = $value === null ? null : (string) $value;
             $this->writeAttribute($writer, $prefix, $name, $namespace, $value);

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -157,7 +157,8 @@ class Serializer
                 if (isset($command[$name])) {
                     $variables[$name] = $arg->filter($command[$name]);
                     if (!is_array($variables[$name])) {
-                        $variables[$name] = (string) NonFiniteFloats::normalize($variables[$name], 'a uri location value');
+                        NonFiniteFloats::assertFinite($variables[$name], 'a uri location value');
+                        $variables[$name] = (string) $variables[$name];
                     }
                 }
             }

--- a/tests/NonFiniteFloatsTest.php
+++ b/tests/NonFiniteFloatsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Command\Guzzle;
+
+use GuzzleHttp\Command\Guzzle\NonFiniteFloats;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \GuzzleHttp\Command\Guzzle\NonFiniteFloats
+ */
+class NonFiniteFloatsTest extends TestCase
+{
+    /**
+     * @dataProvider nonFiniteFloatProvider
+     */
+    public function testAssertFiniteRejectsNonFiniteFloats(float $value): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Non-finite floats are not supported for a query location value.');
+
+        NonFiniteFloats::assertFinite($value, 'a query location value');
+    }
+
+    /**
+     * @dataProvider nonFiniteFloatProvider
+     */
+    public function testAssertAllFiniteRejectsNestedNonFiniteFloats(float $value): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Non-finite floats are not supported for a query location value.');
+
+        NonFiniteFloats::assertAllFinite(['a' => ['b' => $value]], 'a query location value');
+    }
+
+    public function testAssertFiniteAcceptsFiniteAndNonFloatValues(): void
+    {
+        NonFiniteFloats::assertFinite(1.5, 'a query location value');
+        NonFiniteFloats::assertFinite('value', 'a query location value');
+        NonFiniteFloats::assertFinite(1, 'a query location value');
+        NonFiniteFloats::assertAllFinite(['a' => 1.5, 'b' => ['c' => 'value']], 'a query location value');
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public static function nonFiniteFloatProvider(): array
+    {
+        return [
+            'NAN' => [\NAN],
+            'INF' => [\INF],
+            '-INF' => [-\INF],
+        ];
+    }
+}


### PR DESCRIPTION
Non-finite float command values in the query, formParam, body, xml, and uri request locations now throw an `InvalidArgumentException` instead of being coerced to strings. This follows the deprecation added in 1.7. Header location values already reject non-strings, so non-finite floats there were rejected already. Finite floats continue to serialize as before.