### PR TITLE
Normalize multipart non-finite floats

### DIFF
--- a/src/RequestLocation/MultiPartLocation.php
+++ b/src/RequestLocation/MultiPartLocation.php
@@ -38,10 +38,11 @@ class MultiPartLocation extends AbstractLocation
         RequestInterface $request,
         Parameter $param
     ) {
-        $contents = $this->prepareValue($command[$param->getName()], $param);
-        $contents = is_array($contents)
-            ? NonFiniteFloats::normalizeAll($contents, 'a multipart location value')
-            : NonFiniteFloats::normalize($contents, 'a multipart location value');
+        $value = $this->prepareValue($command[$param->getName()], $param);
+
+        $contents = is_array($value)
+            ? NonFiniteFloats::normalizeAll($value, 'a multipart location value')
+            : NonFiniteFloats::normalize($value, 'a multipart location value');
 
         $this->multipartData[] = [
             'name' => $param->getWireName(),

--- a/src/RequestLocation/MultiPartLocation.php
+++ b/src/RequestLocation/MultiPartLocation.php
@@ -3,6 +3,7 @@
 namespace GuzzleHttp\Command\Guzzle\RequestLocation;
 
 use GuzzleHttp\Command\CommandInterface;
+use GuzzleHttp\Command\Guzzle\NonFiniteFloats;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Psr7;
@@ -37,9 +38,14 @@ class MultiPartLocation extends AbstractLocation
         RequestInterface $request,
         Parameter $param
     ) {
+        $contents = $this->prepareValue($command[$param->getName()], $param);
+        $contents = is_array($contents)
+            ? NonFiniteFloats::normalizeAll($contents, 'a multipart location value')
+            : NonFiniteFloats::normalize($contents, 'a multipart location value');
+
         $this->multipartData[] = [
             'name' => $param->getWireName(),
-            'contents' => $this->prepareValue($command[$param->getName()], $param),
+            'contents' => $contents,
         ];
 
         return $request;


### PR DESCRIPTION
This normalizes multipart location values before creating PSR-7 multipart streams so guzzle-services owns the existing non-finite float location deprecation for this path.