### PR TITLE
Reject multipart non-finite floats

### DIFF
--- a/src/RequestLocation/MultiPartLocation.php
+++ b/src/RequestLocation/MultiPartLocation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Command\Guzzle\RequestLocation;
 
 use GuzzleHttp\Command\CommandInterface;
+use GuzzleHttp\Command\Guzzle\NonFiniteFloats;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Psr7;
@@ -32,9 +33,17 @@ class MultiPartLocation extends AbstractLocation
         RequestInterface $request,
         Parameter $param
     ): RequestInterface {
+        $value = $this->prepareValue($command[$param->getName()], $param);
+
+        if (is_array($value)) {
+            NonFiniteFloats::assertAllFinite($value, 'a multipart location value');
+        } else {
+            NonFiniteFloats::assertFinite($value, 'a multipart location value');
+        }
+
         $this->multipartData[] = [
             'name' => $param->getWireName(),
-            'contents' => $this->prepareValue($command[$param->getName()], $param),
+            'contents' => $value,
         ];
 
         return $request;

--- a/tests/RequestLocation/MultiPartLocationTest.php
+++ b/tests/RequestLocation/MultiPartLocationTest.php
@@ -56,4 +56,30 @@ class MultiPartLocationTest extends TestCase
         $this->assertNotFalse(strpos($actual, 'bar'));
         $this->assertSame('application/vnd.example', $request->getHeaderLine('Content-Type'));
     }
+
+    public function testRejectsNonFiniteFloatLocationValues(): void
+    {
+        $location = new MultiPartLocation();
+        $command = new Command('foo', ['foo' => NAN]);
+        $request = new Request('POST', 'http://httbin.org', []);
+        $param = new Parameter(['name' => 'foo']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Non-finite floats are not supported for a multipart location value.');
+
+        $location->visit($command, $request, $param);
+    }
+
+    public function testRejectsNestedNonFiniteFloatLocationValues(): void
+    {
+        $location = new MultiPartLocation();
+        $command = new Command('foo', ['foo' => ['score' => INF]]);
+        $request = new Request('POST', 'http://httbin.org', []);
+        $param = new Parameter(['name' => 'foo']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Non-finite floats are not supported for a multipart location value.');
+
+        $location->visit($command, $request, $param);
+    }
 }


### PR DESCRIPTION
This rejects non-finite float multipart location values before creating multipart request bodies. It applies the existing request location enforcement to the multipart location path.