### PR TITLE
Freeze trim characters ahead of PHP 8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.7.2 - UPCOMING
+
+* Pass explicit trim characters ahead of the PHP 8.6 trim default change
+
 ## 1.7.1 - 2026-06-23
 
 * Require `guzzlehttp/guzzle` ^7.12.3 and `guzzlehttp/psr7` ^2.12.3

--- a/src/ResponseLocation/XmlLocation.php
+++ b/src/ResponseLocation/XmlLocation.php
@@ -314,7 +314,7 @@ class XmlLocation extends AbstractLocation
         }
 
         // Extract text from node
-        $text = trim((string) $xml);
+        $text = trim((string) $xml, " \n\r\t\0\x0B");
         if ($text === '') {
             $text = null;
         }


### PR DESCRIPTION
PHP 8.6 adds the form feed character to the default `$characters` set of `trim`, so the XML response location's text-node extraction, the one call in this package relying on the default, would change behavior there. This change passes the pre-8.6 set explicitly, keeping behavior identical on every PHP version. This is the guzzle-services counterpart of guzzle/guzzle#3775.
