### PR TITLE
Trim XML response text nodes with XML whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Require `null` schema types to match only `null` values
 * Improve PHPDoc for service client transformers, command handler stacks, and service description, operation, and parameter schema arrays
 * Mark `Operation`, `ValidatedDescriptionHandler`, and `Rfc3986Serializer` as soft-final with `@final` annotations
+* Trim XML response text nodes with XML whitespace characters only
 
 ## 1.7.1 - 2026-06-23
 

--- a/src/ResponseLocation/XmlLocation.php
+++ b/src/ResponseLocation/XmlLocation.php
@@ -333,7 +333,7 @@ class XmlLocation extends AbstractLocation
         }
 
         // Extract text from node
-        $text = trim((string) $xml);
+        $text = trim((string) $xml, " \t\n\r");
         if ($text === '') {
             $text = null;
         }


### PR DESCRIPTION
This is the 2.0 counterpart of the 1.7 trim explicitness change. Instead of freezing the pre-8.6 PHP default set, the XML response location now trims text nodes with the XML whitespace characters, space, horizontal tab, carriage return, and line feed, matching the XML 1.0 `S` production. Null bytes and vertical tabs cannot appear in well-formed XML, so this is not observable through documents libxml accepts, and it keeps the trim independent of the PHP 8.6 default change.
