### PR TITLE
Fix enum validation TypeError on non-string enum entries

### DIFF
--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -254,9 +254,7 @@ class SchemaValidator
 
             // Strings can have enums which are a list of predefined values
             if ($enum && !in_array($value, $enum, true)) {
-                $this->errors[] = "{$path} must be one of ".implode(' or ', array_map(function ($s): string {
-                    return '"'.addslashes($s).'"';
-                }, $enum));
+                $this->errors[] = "{$path} must be one of ".implode(' or ', array_map([$this, 'describeEnumValue'], $enum));
             }
 
             $pattern = $param->getPattern();
@@ -307,5 +305,32 @@ class SchemaValidator
         }
 
         return empty($this->errors);
+    }
+
+    /**
+     * Describe an enum entry for an error message without casting values,
+     * such as booleans and non-finite floats, that cannot round-trip.
+     *
+     * @param mixed $value
+     */
+    private function describeEnumValue($value): string
+    {
+        if (is_string($value)) {
+            return '"'.addslashes($value).'"';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_float($value) && !is_finite($value)) {
+            return is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+        }
+
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+
+        return get_debug_type($value);
     }
 }

--- a/tests/SchemaValidatorTest.php
+++ b/tests/SchemaValidatorTest.php
@@ -217,6 +217,22 @@ class SchemaValidatorTest extends TestCase
         ], $this->validator->getErrors());
     }
 
+    public function testValidatesEnumStrictlyAndDescribesNonStringEntries(): void
+    {
+        $param = new Parameter([
+            'name' => 'test',
+            'type' => 'string',
+            'enum' => [1, 'two', true, NAN, -INF],
+        ]);
+        $value = '1';
+
+        $this->assertFalse($this->validator->validate($param, $value));
+        $this->assertEquals(
+            ['[test] must be one of 1 or "two" or true or NAN or -INF'],
+            $this->validator->getErrors()
+        );
+    }
+
     public function testPatternNoMatchReportsValidationError(): void
     {
         $param = new Parameter([


### PR DESCRIPTION
`SchemaValidator` runs under `strict_types`, so when a string parameter declares non-string enum entries such as `['enum' => [1, 2]]`, building the validation error message crashes with a `TypeError` from `addslashes()`. The strict `in_array()` comparison makes this worse: values like `'1'` that matched loosely on 1.7 now always take the error path, so any such description crashes on every validation.

This keeps the strict matching but renders enum entries safely in the message. Strings stay quoted and escaped as before, booleans render as `true` and `false`, integers and finite floats render bare, non-finite floats render as `NAN`, `INF`, or `-INF` rather than being cast, and anything else renders as its type name. Documentation for the strict matching behavior itself follows in a separate docs pull request.
