### PR TITLE
Fix parameter presence and base URI validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Require `guzzlehttp/guzzle` ^8.0 and `guzzlehttp/psr7` ^3.0
 * Require `guzzlehttp/command` ^2.0 and `guzzlehttp/uri-template` ^2.0
 * Remove the legacy `baseUrl` service description option; use `baseUri` instead
+* Reject non-string and non-stringable `baseUri` service-description values before URI construction
 * Remove the legacy `responseClass` operation option; use `responseModel` instead
 * Reject native PHP serialization of runtime client pipeline objects
 * Default operations without an `httpMethod` to `GET`, preserve explicit `httpMethod` casing, and reject invalid `httpMethod` values
@@ -19,6 +20,7 @@
 * Require custom parameter filters and extension points to accept exact value types instead of relying on scalar coercion
 * Validate cast integer values against string enum, pattern, and length constraints
 * Match string enum values strictly by type and value
+* Treat explicit false values as present in `Parameter::has()` while omitted `required` and `static` flags remain absent
 * Limit XML response traversal and additional-property conversion to 512 nested elements by default
 * Serialize XML request scalar element text with XMLWriter text escaping instead of CDATA sections
 * Honor the documented `GuzzleClient` `response_locations` option when building the default deserializer

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,6 +7,18 @@ parameters:
 			path: src/Description.php
 
 		-
+			message: '#^Call to function is_object\(\) with Stringable will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Description.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Stringable and ''__toString'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Description.php
+
+		-
 			message: '#^Negated boolean expression is always false\.$#'
 			identifier: booleanNot.alwaysFalse
 			count: 1

--- a/src/Description.php
+++ b/src/Description.php
@@ -72,7 +72,15 @@ class Description implements DescriptionInterface
         }
 
         // Set the baseUri
-        $this->baseUri = isset($config['baseUri']) ? new Uri((string) $config['baseUri']) : new Uri();
+        if (isset($config['baseUri'])) {
+            $baseUri = $config['baseUri'];
+            if (!is_string($baseUri) && (!is_object($baseUri) || !method_exists($baseUri, '__toString'))) {
+                throw new \InvalidArgumentException(\sprintf('baseUri must be a string or Stringable; got %s.', get_debug_type($baseUri)));
+            }
+            $this->baseUri = new Uri((string) $baseUri);
+        } else {
+            $this->baseUri = new Uri();
+        }
 
         // Ensure that the models and operations properties are always arrays
         $this->models = (array) $this->models;

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -832,6 +832,12 @@ class Parameter implements ToArrayInterface
             return false;
         }
 
+        // The required and static bool properties initialize to false, so their
+        // presence must come from the resolved schema data instead of isset().
+        if (($var === 'required' || $var === 'static') && !array_key_exists($var, $this->resolvedData)) {
+            return false;
+        }
+
         $value = $this->{$var};
 
         return $value !== '' && $value !== [];

--- a/tests/DescriptionTest.php
+++ b/tests/DescriptionTest.php
@@ -139,6 +139,38 @@ class DescriptionTest extends TestCase
         $this->assertEquals('http://foo.com', $description->getBaseUri());
     }
 
+    /**
+     * @dataProvider invalidBaseUriProvider
+     */
+    public function testValidatesBaseUriType($baseUri, string $type): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('baseUri must be a string or Stringable; got '.$type.'.');
+
+        new Description(['baseUri' => $baseUri]);
+    }
+
+    public static function invalidBaseUriProvider(): array
+    {
+        return [
+            'array' => [[], 'array'],
+            'object' => [new \stdClass(), 'stdClass'],
+        ];
+    }
+
+    public function testAcceptsStringableBaseUri(): void
+    {
+        $baseUri = new class {
+            public function __toString(): string
+            {
+                return 'http://foo.com';
+            }
+        };
+
+        $description = new Description(['baseUri' => $baseUri]);
+        $this->assertEquals('http://foo.com', $description->getBaseUri());
+    }
+
     public function testModelsHaveNames(): void
     {
         $desc = [

--- a/tests/ParameterTest.php
+++ b/tests/ParameterTest.php
@@ -501,4 +501,31 @@ class ParameterTest extends TestCase
         $this->assertFalse((new Parameter(['type' => '']))->has('type'));
         $this->assertFalse((new Parameter(['type' => []]))->has('type'));
     }
+
+    public function testHasDistinguishesOmittedAndExplicitBooleanFlags(): void
+    {
+        $omitted = new Parameter();
+
+        $this->assertFalse($omitted->has('required'));
+        $this->assertFalse($omitted->has('static'));
+
+        $explicitFalse = new Parameter(['required' => false, 'static' => false]);
+
+        $this->assertTrue($explicitFalse->has('required'));
+        $this->assertTrue($explicitFalse->has('static'));
+    }
+
+    public function testHasTreatsInheritedFalseBooleanFlagsAsPresent(): void
+    {
+        $description = new Description([
+            'models' => [
+                'Base' => ['required' => false, 'static' => false],
+            ],
+        ]);
+
+        $parameter = new Parameter(['extends' => 'Base'], ['description' => $description]);
+
+        $this->assertTrue($parameter->has('required'));
+        $this->assertTrue($parameter->has('static'));
+    }
 }


### PR DESCRIPTION
`Parameter::has()` returned true for omitted `required` and `static` flags because the native bool properties initialize to false and `isset()` always passes for them, contradicting the presence semantics documented in the upgrade guide. Presence for those two flags now comes from the resolved schema data, so omitted flags read as absent while explicit and inherited false values remain present. `Description` also cast any `baseUri` value straight to string, turning an array into the literal URI `Array`; non-string, non-stringable values are now rejected with an `InvalidArgumentException` before URI construction. Both fixes come with tests and changelog entries.