### PR TITLE
Complete remaining 2.0 release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,18 @@
 * Return raw PSR-7 responses in the `response` result key when the `process` client option is `false`
 * Allow operations to override response processing with the `process` operation option
 * Support JSON response fields with multiple allowed `type` values
+* Reject scalar top-level JSON response bodies
 * Require custom implementations and subclasses of public service APIs to match native method signatures
 * Require custom parameter filters and extension points to accept exact value types instead of relying on scalar coercion
 * Validate cast integer values against string enum, pattern, and length constraints
 * Match string enum values strictly by type and value
+* Normalize stringable command values for string parameters during validation
 * Treat explicit false values as present in `Parameter::has()` while omitted `required` and `static` flags remain absent
 * Limit XML response traversal and additional-property conversion to 512 nested elements by default
 * Serialize XML request scalar element text with XMLWriter text escaping instead of CDATA sections
 * Honor the documented `GuzzleClient` `response_locations` option when building the default deserializer
 * Reject invalid `GuzzleClient` configuration option values
+* Reject loose parameter schema values instead of normalizing them
 * Require `null` schema types to match only `null` values
 * Improve PHPDoc for service client transformers, command handler stacks, and service description, operation, and parameter schema arrays
 * Mark `Operation`, `ValidatedDescriptionHandler`, and `Rfc3986Serializer` as soft-final with `@final` annotations

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -142,6 +142,14 @@ $contents = (string) $result['output'];
 $contents = $result['output'];
 ```
 
+#### JSON Response Bodies
+
+JSON response processing now requires the top-level JSON value to be an object
+or array. Scalar JSON bodies such as `null`, numbers, strings, and booleans now
+throw `RuntimeException`. For endpoints that intentionally return scalar JSON,
+disable response processing with `process: false` and read the raw PSR-7
+response from the result's `response` key.
+
 #### Null Schema Values
 
 Schema parameters with `type` set to `'null'` now match only actual `null`
@@ -249,6 +257,14 @@ Services 1.x skipped those checks for cast integers. Enum matching is also
 strict: values match only enum entries of the same type, so string parameters
 must declare enum entries as strings (`'1'` rather than `1`).
 
+#### Stringable Command Values
+
+When validation is enabled, command values for parameters with `type: string`
+may be stringable objects. Successful validation casts those values to strings
+and stores the normalized strings back on the command before the next handler
+runs. Normalize these values before creating the command if later middleware
+expects the original object instance.
+
 #### Non-finite Float Command Values
 
 Command values serialized into request locations now reject `NAN`, `INF`, and
@@ -280,6 +296,13 @@ Service description values must use the documented PHP types, such as strings
 for names and URIs, booleans for flags, arrays for schema collections, and
 integers for min/max constraints. Parameter schema values that Guzzle Services
 1.6 deprecated and normalized are rejected instead of being cast.
+
+This applies to documented parameter schema keys such as `name`, `description`,
+`location`, `sentAs`, `pattern`, `format`, `$ref`, `extends`, `required`,
+`static`, `minimum`, `maximum`, `minLength`, `maxLength`, `minItems`,
+`maxItems`, `filters`, `properties`, `data`, `enum`, `additionalProperties`,
+`items`, and `type`. Other keys, including `default` and unknown custom keys,
+are retained as parameter data without strict rejection.
 
 #### Soft-Final Classes
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -13,11 +13,25 @@ $description = new Description([
             'httpMethod' => 'GET',
             'uri' => '/metadata/{id}',
             'responseModel' => 'metadataResponse',
+            'parameters' => [
+                'id' => [
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'uri',
+                ],
+            ],
         ],
         'getFile' => [
             'httpMethod' => 'GET',
             'uri' => '/files/{id}',
             'process' => false,
+            'parameters' => [
+                'id' => [
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'uri',
+                ],
+            ],
         ],
     ],
 ]);
@@ -26,7 +40,7 @@ $description = new Description([
 When response processing is disabled, the raw PSR-7 response is returned in the result's `response` key:
 
 ```php
-$result = $guzzleClient->getFile(['id' => 123]);
+$result = $guzzleClient->getFile(['id' => '123']);
 $response = $result['response'];
 ```
 


### PR DESCRIPTION
This completes the remaining 2.0 release documentation. The changelog gains entries for stringable command-value normalization, the rejection of loose parameter schema values, and the rejection of scalar top-level JSON response bodies. The upgrade guide gains matching sections explaining that successful validation writes normalized strings back onto the command, which schema keys strict normalization covers, and how to handle endpoints that intentionally return scalar JSON via `process: false`.

The raw-response cookbook recipe also passed `id` to `getFile()` without declaring an `id` URI parameter, so `{id}` was never populated when the snippet was copied as-is. Both example operations now declare the parameter and the example call passes a string, matching the serializer's URI-template variable collection.