### PR TITLE
Cover new validation branches

### DIFF
--- a/tests/Handler/ValidatedDescriptionHandlerTest.php
+++ b/tests/Handler/ValidatedDescriptionHandlerTest.php
@@ -118,4 +118,39 @@ class ValidatedDescriptionHandlerTest extends TestCase
         // Should not throw any exception
         self::assertInstanceOf(Result::class, $client->foo(['bar' => new \DateTimeImmutable()]));
     }
+
+    public function testWritesNormalizedStringableValuesBackToCommand(): void
+    {
+        $description = new Description([
+            'operations' => [
+                'foo' => [
+                    'uri' => Server::$url,
+                    'httpMethod' => 'GET',
+                    'parameters' => [
+                        'bar' => [
+                            'type' => 'string',
+                            'location' => 'query',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        Server::flush();
+        Server::enqueue([new Response(200)]);
+
+        $client = new GuzzleClient(new HttpClient(), $description);
+        $command = $client->getCommand('foo', [
+            'bar' => new class {
+                public function __toString(): string
+                {
+                    return 'stringable';
+                }
+            },
+        ]);
+
+        $client->execute($command);
+
+        self::assertSame('stringable', $command['bar']);
+    }
 }

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -218,6 +218,20 @@ class OperationTest extends TestCase
         $this->assertEquals('string', $o->getAdditionalParameters()->getType());
     }
 
+    public function testCanProvideAdditionalParametersAsParameter(): void
+    {
+        $parameter = new Parameter(['type' => 'string']);
+        $operation = new Operation(['additionalParameters' => $parameter]);
+        $this->assertSame($parameter, $operation->getAdditionalParameters());
+    }
+
+    public function testEnsuresAdditionalParametersAreArrayOrParameter(): void
+    {
+        $this->expectExceptionMessage('additionalParameters must be an array or Parameter');
+        $this->expectException(\InvalidArgumentException::class);
+        new Operation(['additionalParameters' => true]);
+    }
+
     protected function getOperation(): Operation
     {
         return new Operation([

--- a/tests/SchemaValidatorTest.php
+++ b/tests/SchemaValidatorTest.php
@@ -458,6 +458,35 @@ class SchemaValidatorTest extends TestCase
         $this->assertEquals('12', $value);
     }
 
+    public function testCastsIntegerBeforeStringConstraintValidation(): void
+    {
+        $param = new Parameter([
+            'name' => 'test',
+            'type' => 'string',
+            'enum' => ['7'],
+        ]);
+        $value = 12;
+        $this->assertFalse($this->validator->validate($param, $value));
+        $this->assertSame('12', $value);
+        $this->assertEquals(['[test] must be one of "7"'], $this->validator->getErrors());
+    }
+
+    public function testNormalizesStringableValuesToStrings(): void
+    {
+        $param = new Parameter([
+            'name' => 'test',
+            'type' => 'string',
+        ]);
+        $value = new class {
+            public function __toString(): string
+            {
+                return 'stringable';
+            }
+        };
+        $this->assertTrue($this->validator->validate($param, $value));
+        $this->assertSame('stringable', $value);
+    }
+
     public function testRequiredMessageIncludesType(): void
     {
         $param = new Parameter([


### PR DESCRIPTION
This pins under-covered 2.0 validation and operation-construction behavior with test-only changes. Cast integers are proven to be validated against string constraints after conversion, with the failed value visible as the cast string. Stringable command values are proven to normalize to strings during successful validation, both directly against `SchemaValidator` and end-to-end through `ValidatedDescriptionHandler`, which writes the normalized string back onto the executed command. `Operation` is proven to pass an existing `Parameter` instance through `additionalParameters` unchanged and to reject truthy invalid values with the documented exception. The mutated-value assertions use `assertSame` because PHPUnit's loose comparator would pass without the casts.