### PR TITLE
Wrap documentation prose to 80 columns

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,10 +1,15 @@
 # Cookbook
 
-This cookbook collects focused recipes for common Guzzle Services tasks. It assumes you already have a `GuzzleHttp\Command\Guzzle\Description` and a `GuzzleHttp\Command\Guzzle\GuzzleClient`; see [Service Descriptions](service-descriptions.md) for the full description format.
+This cookbook collects focused recipes for common Guzzle Services tasks. It
+assumes you already have a `GuzzleHttp\Command\Guzzle\Description` and a
+`GuzzleHttp\Command\Guzzle\GuzzleClient`; see
+[Service Descriptions](service-descriptions.md) for the full description format.
 
 ## Returning Raw Responses
 
-By default, responses are parsed according to the operation's `responseModel`. For operations that return binary data or another response body that should not be parsed, set `process` to `false` on that operation:
+By default, responses are parsed according to the operation's `responseModel`.
+For operations that return binary data or another response body that should not
+be parsed, set `process` to `false` on that operation:
 
 ```php
 $description = new Description([
@@ -37,18 +42,22 @@ $description = new Description([
 ]);
 ```
 
-When response processing is disabled, the raw PSR-7 response is returned in the result's `response` key:
+When response processing is disabled, the raw PSR-7 response is returned in the
+result's `response` key:
 
 ```php
 $result = $guzzleClient->getFile(['id' => '123']);
 $response = $result['response'];
 ```
 
-Operation-level `process` overrides the client-level `process` option. If an operation omits `process`, or sets it to `null`, it inherits the client setting.
+Operation-level `process` overrides the client-level `process` option. If an
+operation omits `process`, or sets it to `null`, it inherits the client setting.
 
 ## Adding Client Defaults
 
-Use client `defaults` for command parameters that should be present on most or all commands, such as an API key, tenant ID, or shared query flag. Explicit command arguments override defaults.
+Use client `defaults` for command parameters that should be present on most or
+all commands, such as an API key, tenant ID, or shared query flag. Explicit
+command arguments override defaults.
 
 ```php
 use GuzzleHttp\Client;
@@ -70,7 +79,9 @@ $guzzleClient = new GuzzleClient(
 $result = $guzzleClient->listUsers();
 ```
 
-The default still needs a matching parameter schema, or an operation-level `additionalParameters` schema, so built-in validation and serialization know how to handle it:
+The default still needs a matching parameter schema, or an operation-level
+`additionalParameters` schema, so built-in validation and serialization know how
+to handle it:
 
 ```php
 'parameters' => [
@@ -84,7 +95,9 @@ The default still needs a matching parameter schema, or an operation-level `addi
 
 ## Modeling JSON Response Fields with Multiple Types
 
-Some JSON APIs return the same field with different types depending on the data. For example, a response field might be `null`, a string, or an array of strings. Model this by setting `type` to an array of allowed types:
+Some JSON APIs return the same field with different types depending on the data.
+For example, a response field might be `null`, a string, or an array of strings.
+Model this by setting `type` to an array of allowed types:
 
 ```php
 $description = new Description([
@@ -114,7 +127,8 @@ $description = new Description([
 
 ## Changing Query Parameter Serialization
 
-By default, query parameters are serialized with strict RFC 3986 encoding using PHP-style array indexes. Array query parameters are serialized like this:
+By default, query parameters are serialized with strict RFC 3986 encoding using
+PHP-style array indexes. Array query parameters are serialized like this:
 
 ```php
 $client->myMethod(['foo' => ['bar', 'baz']]);
@@ -122,7 +136,9 @@ $client->myMethod(['foo' => ['bar', 'baz']]);
 // Query parameters will be foo%5B0%5D=bar&foo%5B1%5D=baz
 ```
 
-Some APIs require numeric indexes to be removed, so the query string becomes `foo%5B%5D=bar&foo%5B%5D=baz`. Change this behavior by creating a query location with a different serializer and passing it to the request serializer:
+Some APIs require numeric indexes to be removed, so the query string becomes
+`foo%5B%5D=bar&foo%5B%5D=baz`. Change this behavior by creating a query location
+with a different serializer and passing it to the request serializer:
 
 ```php
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
@@ -135,7 +151,8 @@ $serializer = new Serializer($description, ['query' => $queryLocation]);
 $guzzleClient = new GuzzleClient($client, $description, $serializer);
 ```
 
-You can also implement your own query serializer or replace the `query` request location if your API needs a different query format.
+You can also implement your own query serializer or replace the `query` request
+location if your API needs a different query format.
 
 ## Related
 

--- a/docs/service-client-extension-points.md
+++ b/docs/service-client-extension-points.md
@@ -1,6 +1,13 @@
 # Service Client Extension Points
 
-`GuzzleHttp\Command\Guzzle\GuzzleClient` adapts Guzzle Command service clients to service descriptions. It supplies default request serialization, response deserialization, validation middleware, and client configuration, while leaving each part replaceable. This page covers extension points specific to Guzzle Services; the base command client concepts are documented in [Guzzle Command service clients](https://github.com/guzzle/command/blob/2.0/docs/service-clients.md) and [Guzzle Command middleware](https://github.com/guzzle/command/blob/2.0/docs/middleware-extending-the-client.md).
+`GuzzleHttp\Command\Guzzle\GuzzleClient` adapts Guzzle Command service clients
+to service descriptions. It supplies default request serialization, response
+deserialization, validation middleware, and client configuration, while leaving
+each part replaceable. This page covers extension points specific to Guzzle
+Services; the base command client concepts are documented in
+[Guzzle Command service clients](https://github.com/guzzle/command/blob/2.0/docs/service-clients.md)
+and
+[Guzzle Command middleware](https://github.com/guzzle/command/blob/2.0/docs/middleware-extending-the-client.md).
 
 ## Constructor Extension Points
 
@@ -33,7 +40,8 @@ callable(
 ): GuzzleHttp\Command\ResultInterface
 ```
 
-The fifth argument is a command `GuzzleHttp\HandlerStack` whose handlers follow this shape:
+The fifth argument is a command `GuzzleHttp\HandlerStack` whose handlers follow
+this shape:
 
 ```php
 callable(
@@ -45,9 +53,13 @@ The sixth argument is the Guzzle Services client config array.
 
 ## Custom Request Locations
 
-Request locations serialize operation parameters into parts of a PSR-7 request. The built-in request locations are `query`, `header`, `body`, `json`, `xml`, `formParam`, and `multipart`. The `uri` location is handled separately by URI template expansion.
+Request locations serialize operation parameters into parts of a PSR-7 request.
+The built-in request locations are `query`, `header`, `body`, `json`, `xml`,
+`formParam`, and `multipart`. The `uri` location is handled separately by URI
+template expansion.
 
-Pass custom locations to `Serializer` as an associative array keyed by location name. Custom keys override built-in keys with the same name.
+Pass custom locations to `Serializer` as an associative array keyed by location
+name. Custom keys override built-in keys with the same name.
 
 ```php
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
@@ -63,13 +75,20 @@ $serializer = new Serializer($description, [
 $client = new GuzzleClient($httpClient, $description, $serializer);
 ```
 
-A custom request location implements `GuzzleHttp\Command\Guzzle\RequestLocation\RequestLocationInterface`. `visit()` is called for each matching parameter, and `after()` is called once after all visited parameters for that location. `after()` is where locations usually handle `additionalParameters`.
+A custom request location implements
+`GuzzleHttp\Command\Guzzle\RequestLocation\RequestLocationInterface`. `visit()`
+is called for each matching parameter, and `after()` is called once after all
+visited parameters for that location. `after()` is where locations usually
+handle `additionalParameters`.
 
 ## Custom Response Locations
 
-Response locations deserialize parts of a PSR-7 response into command result fields. The built-in response locations are `json`, `xml`, `header`, `body`, `statusCode`, and `reasonPhrase`.
+Response locations deserialize parts of a PSR-7 response into command result
+fields. The built-in response locations are `json`, `xml`, `header`, `body`,
+`statusCode`, and `reasonPhrase`.
 
-When using the default deserializer, add or replace response locations with client config:
+When using the default deserializer, add or replace response locations with
+client config:
 
 ```php
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
@@ -88,11 +107,18 @@ $client = new GuzzleClient(
 );
 ```
 
-A custom response location implements `GuzzleHttp\Command\Guzzle\ResponseLocation\ResponseLocationInterface`. `before()` is called once before visiting matching model properties, `visit()` is called for each matching property, and `after()` is called after all matching properties are visited.
+A custom response location implements
+`GuzzleHttp\Command\Guzzle\ResponseLocation\ResponseLocationInterface`.
+`before()` is called once before visiting matching model properties, `visit()`
+is called for each matching property, and `after()` is called after all matching
+properties are visited.
 
 ## Custom Serializer and Deserializer
 
-`Serializer` and `Deserializer` are invokable objects, so they can be passed directly to the `GuzzleClient` constructor. Pass a `Serializer` when you only need to customize request locations; pass a `Deserializer` when you need to customize response locations or response-processing behavior.
+`Serializer` and `Deserializer` are invokable objects, so they can be passed
+directly to the `GuzzleClient` constructor. Pass a `Serializer` when you only
+need to customize request locations; pass a `Deserializer` when you need to
+customize response locations or response-processing behavior.
 
 ```php
 use GuzzleHttp\Command\Guzzle\Deserializer;
@@ -115,11 +141,17 @@ $client = new GuzzleClient(
 );
 ```
 
-You can also pass any callable with the constructor signatures shown above. When you provide a custom response transformer, `response_locations` and client-level `process` config are not applied to it automatically; wire those concerns into your transformer if you need them.
+You can also pass any callable with the constructor signatures shown above. When
+you provide a custom response transformer, `response_locations` and client-level
+`process` config are not applied to it automatically; wire those concerns into
+your transformer if you need them.
 
 ## Command Handler Stack
 
-The command handler stack is separate from the underlying Guzzle HTTP handler stack. Command middleware wraps commands before they are transformed into HTTP requests; HTTP middleware belongs on the underlying `GuzzleHttp\ClientInterface` instead.
+The command handler stack is separate from the underlying Guzzle HTTP handler
+stack. Command middleware wraps commands before they are transformed into HTTP
+requests; HTTP middleware belongs on the underlying `GuzzleHttp\ClientInterface`
+instead.
 
 ```php
 use GuzzleHttp\Command\CommandInterface;
@@ -135,7 +167,8 @@ $client->getHandlerStack()->push(function (callable $handler) {
 }, 'timeout');
 ```
 
-The special `@http` command key is consumed by the base command client and passed as request options to the underlying HTTP client's `sendAsync()` call.
+The special `@http` command key is consumed by the base command client and
+passed as request options to the underlying HTTP client's `sendAsync()` call.
 
 ## Client Config
 
@@ -148,13 +181,24 @@ The special `@http` command key is consumed by the base command client and passe
 | `process` | Boolean. Enables or disables default response processing during construction. Defaults to `true`. Operation `process` can override it. |
 | `response_locations` | Map of response location names to `ResponseLocationInterface` instances used by the default deserializer. |
 
-`defaults` is read when commands are created, so changing it with `setConfig()` affects later commands. `validate`, `process`, and `response_locations` have constructor-only effects in the default client because they install middleware or build the default deserializer during construction.
+`defaults` is read when commands are created, so changing it with `setConfig()`
+affects later commands. `validate`, `process`, and `response_locations` have
+constructor-only effects in the default client because they install middleware
+or build the default deserializer during construction.
 
 ## Constructor-Only `validate` and `process` Effects
 
-Validation is implemented by pushing `ValidatedDescriptionHandler` onto the command handler stack in the constructor. Calling `setConfig('validate', false)` later only changes the stored config value; it does not remove the middleware from the stack.
+Validation is implemented by pushing `ValidatedDescriptionHandler` onto the
+command handler stack in the constructor. Calling `setConfig('validate', false)`
+later only changes the stored config value; it does not remove the middleware
+from the stack.
 
-Response processing is captured when the default `Deserializer` is created in the constructor. Calling `setConfig('process', false)` later only changes the stored config value; it does not replace the deserializer. To change response processing per operation, set the operation's `process` key. To change response processing globally after construction, create a new client with the desired config or pass your own response transformer.
+Response processing is captured when the default `Deserializer` is created in
+the constructor. Calling `setConfig('process', false)` later only changes the
+stored config value; it does not replace the deserializer. To change response
+processing per operation, set the operation's `process` key. To change response
+processing globally after construction, create a new client with the desired
+config or pass your own response transformer.
 
 ## Related
 

--- a/docs/service-descriptions.md
+++ b/docs/service-descriptions.md
@@ -1,6 +1,12 @@
 # Service Descriptions
 
-Service descriptions are arrays consumed by `GuzzleHttp\Command\Guzzle\Description`, `Operation`, `Parameter`, `Serializer`, and `Deserializer`. They describe an API in terms of named commands, how command input becomes an HTTP request, and how an HTTP response becomes a command result. This page covers the Guzzle Services description format; the lower-level command client lifecycle is documented in [Guzzle Command service clients](https://github.com/guzzle/command/blob/2.0/docs/service-clients.md).
+Service descriptions are arrays consumed by
+`GuzzleHttp\Command\Guzzle\Description`, `Operation`, `Parameter`, `Serializer`,
+and `Deserializer`. They describe an API in terms of named commands, how command
+input becomes an HTTP request, and how an HTTP response becomes a command
+result. This page covers the Guzzle Services description format; the lower-level
+command client lifecycle is documented in
+[Guzzle Command service clients](https://github.com/guzzle/command/blob/2.0/docs/service-clients.md).
 
 ```php
 use GuzzleHttp\Client;
@@ -104,15 +110,21 @@ The top-level description array supports these common keys:
 | `operations` | Map of operation names to operation definitions. |
 | `models` | Map of reusable model names to parameter/model schemas. |
 
-Unknown top-level keys are retained as extra data and can be read with `Description::getData()`.
+Unknown top-level keys are retained as extra data and can be read with
+`Description::getData()`.
 
 ## Base URI
 
-`baseUri` is converted to a PSR-7 URI and combined with each operation `uri`. Relative operation URIs are resolved against `baseUri`; absolute operation URIs replace it. If an operation sets `uri` to `null`, the request is created directly from `baseUri`.
+`baseUri` is converted to a PSR-7 URI and combined with each operation `uri`.
+Relative operation URIs are resolved against `baseUri`; absolute operation URIs
+replace it. If an operation sets `uri` to `null`, the request is created
+directly from `baseUri`.
 
 ## Operations
 
-Each operation becomes a command that can be executed with `$client->operationName([...])`, `$client->operationNameAsync([...])`, or `$client->getCommand('operationName', [...])`.
+Each operation becomes a command that can be executed with
+`$client->operationName([...])`, `$client->operationNameAsync([...])`, or
+`$client->getCommand('operationName', [...])`.
 
 | Key | Purpose |
 | --- | --- |
@@ -126,11 +138,18 @@ Each operation becomes a command that can be executed with `$client->operationNa
 | `deprecated` | Boolean flag exposed by `Operation::getDeprecated()`. |
 | `errorResponses` | List of HTTP error mappings with `code`, optional `phrase`, and exception `class`. |
 
-Operations also accept descriptive keys such as `summary`, `notes`, `documentationUrl`, and `data`. Values in `data` are available to custom serializers and locations through `Operation::getData()`.
+Operations also accept descriptive keys such as `summary`, `notes`,
+`documentationUrl`, and `data`. Values in `data` are available to custom
+serializers and locations through `Operation::getData()`.
 
 ## URI Templates
 
-Operation `uri` values are expanded with `guzzlehttp/uri-template`. Only parameters with `location` set to `uri` are provided to URI template expansion. Use `location: query` when you want Guzzle Services to append query parameters after template expansion, or use URI Template query expressions like `{?filter*}` with `location: uri` when the template should control query expansion.
+Operation `uri` values are expanded with `guzzlehttp/uri-template`. Only
+parameters with `location` set to `uri` are provided to URI template expansion.
+Use `location: query` when you want Guzzle Services to append query parameters
+after template expansion, or use URI Template query expressions like
+`{?filter*}` with `location: uri` when the template should control query
+expansion.
 
 ```php
 'operations' => [
@@ -145,11 +164,18 @@ Operation `uri` values are expanded with `guzzlehttp/uri-template`. Only paramet
 ]
 ```
 
-See [URI Template usage](https://github.com/guzzle/uri-template/blob/2.0/docs/uri-template-usage.md) for supported RFC 6570 expressions and [URI Template input contract](https://github.com/guzzle/uri-template/blob/2.0/docs/input-contract.md) for accepted variable values.
+See
+[URI Template usage](https://github.com/guzzle/uri-template/blob/2.0/docs/uri-template-usage.md)
+for supported RFC 6570 expressions and
+[URI Template input contract](https://github.com/guzzle/uri-template/blob/2.0/docs/input-contract.md)
+for accepted variable values.
 
 ## Parameters and Models
 
-Operation parameters and models use the same schema class, `GuzzleHttp\Command\Guzzle\Parameter`. A model is a named reusable schema in the top-level `models` map. A parameter is an operation input schema in an operation's `parameters` map.
+Operation parameters and models use the same schema class,
+`GuzzleHttp\Command\Guzzle\Parameter`. A model is a named reusable schema in the
+top-level `models` map. A parameter is an operation input schema in an
+operation's `parameters` map.
 
 | Key | Purpose |
 | --- | --- |
@@ -167,7 +193,8 @@ Operation parameters and models use the same schema class, `GuzzleHttp\Command\G
 | `$ref` | Reference to a top-level model. The referenced model is resolved into the parameter. |
 | `extends` | Name of a top-level model to inherit from. Local schema keys override inherited keys. Nested maps such as `properties` are not deep-merged. |
 
-Schemas also support validation-oriented keys such as `enum`, `pattern`, `minimum`, `maximum`, `minLength`, `maxLength`, `minItems`, and `maxItems`.
+Schemas also support validation-oriented keys such as `enum`, `pattern`,
+`minimum`, `maximum`, `minLength`, `maxLength`, `minItems`, and `maxItems`.
 
 ## Request Locations
 
@@ -186,7 +213,9 @@ Request locations are used by operation parameters during serialization.
 
 ## Models
 
-Models are reusable parameter schemas. A response model must have top-level `type` set to `object` or `array`; other response model types are rejected by the deserializer.
+Models are reusable parameter schemas. A response model must have top-level
+`type` set to `object` or `array`; other response model types are rejected by
+the deserializer.
 
 ```php
 'models' => [
@@ -207,7 +236,8 @@ Models are reusable parameter schemas. A response model must have top-level `typ
 
 ## Response Models
 
-Response model properties use response locations to pull data from the PSR-7 response.
+Response model properties use response locations to pull data from the PSR-7
+response.
 
 | Location | Behavior |
 | --- | --- |
@@ -218,13 +248,21 @@ Response model properties use response locations to pull data from the PSR-7 res
 | `statusCode` | Stores the integer response status code. |
 | `reasonPhrase` | Stores the response reason phrase. |
 
-If an operation has no `responseModel`, response processing returns an empty `GuzzleHttp\Command\Result`. If `process` is disabled, response processing returns a result with the raw PSR-7 response in the `response` key.
+If an operation has no `responseModel`, response processing returns an empty
+`GuzzleHttp\Command\Result`. If `process` is disabled, response processing
+returns a result with the raw PSR-7 response in the `response` key.
 
 ## Defaults and Validation
 
-`GuzzleClient` merges client `defaults` into command input when commands are created. Explicit command arguments win over defaults.
+`GuzzleClient` merges client `defaults` into command input when commands are
+created. Explicit command arguments win over defaults.
 
-Validation is enabled by default. It checks required values, types, object properties, additional properties, array items, ranges, lengths, enums, and patterns. It also applies parameter `default` and `static` values. Request serialization and response processing apply the full `filters` and `format` pipeline; validation does limited pre-validation filtering/formatting for present truthy values.
+Validation is enabled by default. It checks required values, types, object
+properties, additional properties, array items, ranges, lengths, enums, and
+patterns. It also applies parameter `default` and `static` values. Request
+serialization and response processing apply the full `filters` and `format`
+pipeline; validation does limited pre-validation filtering/formatting for
+present truthy values.
 
 ```php
 $client = new GuzzleClient($httpClient, $description, null, null, null, [
@@ -233,11 +271,16 @@ $client = new GuzzleClient($httpClient, $description, null, null, null, [
 ]);
 ```
 
-The `validate` option installs a command handler during construction. Changing `validate` with `setConfig()` after construction does not add or remove that handler.
+The `validate` option installs a command handler during construction. Changing
+`validate` with `setConfig()` after construction does not add or remove that
+handler.
 
 ## Response Processing
 
-Response processing is enabled by default. Set client config `process` to `false` to return raw responses for all operations, or set operation `process` to override the client setting for a single operation. Operation `process: null` inherits the client setting.
+Response processing is enabled by default. Set client config `process` to
+`false` to return raw responses for all operations, or set operation `process`
+to override the client setting for a single operation. Operation `process: null`
+inherits the client setting.
 
 ```php
 'operations' => [
@@ -252,11 +295,16 @@ Response processing is enabled by default. Set client config `process` to `false
 ]
 ```
 
-The client-level `process` option is used when the default deserializer is constructed. Changing it with `setConfig()` after construction does not replace the deserializer.
+The client-level `process` option is used when the default deserializer is
+constructed. Changing it with `setConfig()` after construction does not replace
+the deserializer.
 
 ## Error Responses
 
-`errorResponses` maps specific HTTP responses to exception classes. Each entry must include `code`, may include `phrase`, and must include `class`. If both `code` and `phrase` are set, both must match. If only `code` is set, the status code match is enough.
+`errorResponses` maps specific HTTP responses to exception classes. Each entry
+must include `code`, may include `phrase`, and must include `class`. If both
+`code` and `phrase` are set, both must match. If only `code` is set, the status
+code match is enough.
 
 ```php
 'errorResponses' => [
@@ -272,7 +320,12 @@ The client-level `process` option is used when the default deserializer is const
 ]
 ```
 
-Exception classes should extend `GuzzleHttp\Command\Exception\CommandException` when you want the custom exception class to propagate from the command layer. Other compatible exception classes are wrapped by the command layer. `errorResponses` are checked only when response processing is enabled. Unmatched HTTP errors can still be raised by the underlying Guzzle HTTP client when `http_errors` is enabled.
+Exception classes should extend `GuzzleHttp\Command\Exception\CommandException`
+when you want the custom exception class to propagate from the command layer.
+Other compatible exception classes are wrapped by the command layer.
+`errorResponses` are checked only when response processing is enabled. Unmatched
+HTTP errors can still be raised by the underlying Guzzle HTTP client when
+`http_errors` is enabled.
 
 ## Related
 


### PR DESCRIPTION
Reflows the documentation prose in the docs pages to a greedy 80-column width so the Markdown reads consistently and diffs stay small. This only moves line breaks; no wording changes, and fenced code blocks, tables, and headings are left untouched. There are no code changes.