### PR TITLE
Use locale-independent ASCII folding for HTTP method casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.7.3 - Upcoming
+
+* Normalize operation HTTP methods with locale-independent ASCII uppercasing
+
 ## 1.7.2 - 2026-07-08
 
 * Require `guzzlehttp/guzzle` ^7.13.3 and `guzzlehttp/psr7` ^2.12.4

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -138,7 +138,7 @@ class Serializer
             /** @var mixed $method */
             $method = $operation->getHttpMethod() ?: 'GET';
             if (is_string($method)) {
-                $normalizedMethod = strtoupper($method);
+                $normalizedMethod = strtr($method, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
                 if ($method !== $normalizedMethod) {
                     \trigger_deprecation(
                         'guzzlehttp/guzzle-services',
@@ -186,7 +186,7 @@ class Serializer
         /** @var mixed $method */
         $method = $operation->getHttpMethod() ?: 'GET';
         if (is_string($method)) {
-            $normalizedMethod = strtoupper($method);
+            $normalizedMethod = strtr($method, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
             if ($method !== $normalizedMethod) {
                 \trigger_deprecation(
                     'guzzlehttp/guzzle-services',


### PR DESCRIPTION
PHP's `strtoupper()` honors `LC_CTYPE` before PHP 8.2, so under single-byte locales such as Turkish a lowercase `i` uppercases to a non-ASCII byte and the deprecation shim that normalizes operation `httpMethod` casing could corrupt the method or misfire the comparison. This converts both `Serializer` shim sites to inline locale-independent `strtr()` ASCII folds. The shims are removed in 2.0, which preserves method casing, so this is the terminal change for the 1.x line.