### PR TITLE
Use ASCII case folding for magic command names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@
   where they are accepted and we need to cast to a string, we should branch on
   `\is_finite($value)`, using `(string) $value` for the finite case and
   `\is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF')` otherwise.
+- Never call `strtolower()`, `strtoupper()`, `strcasecmp()`, `stripos()`, or
+  other locale-sensitive case functions; use the locale-independent
+  `GuzzleHttp\Psr7\Utils::asciiToLower()`, `asciiToUpper()`,
+  `caselessEquals()`, and `caselessContains()` helpers instead.
 - Changes in behavior need a `CHANGELOG.md` entry in the unreleased section of
   the target branch and an `UPGRADING.md` note when the behavior differs between
   major versions.

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Command\ResultInterface;
 use GuzzleHttp\Command\ServiceClient;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -86,7 +87,7 @@ class GuzzleClient extends ServiceClient
     public function getCommand(string $name, array $args = []): CommandInterface
     {
         if (!$this->description->hasOperation($name)) {
-            $name = ucfirst($name);
+            $name = $name === '' ? '' : Utils::asciiToUpper($name[0]).substr($name, 1);
             if (!$this->description->hasOperation($name)) {
                 throw new \InvalidArgumentException(
                     "No operation found named {$name}"


### PR DESCRIPTION
The wider locale audit found one site the strtolower sweep missed: `GuzzleClient::__call()` capitalizes command names with `ucfirst()`, which is locale-sensitive before PHP 8.2 like the rest of the case-function family, so a magic method starting with `i` resolves to a corrupted command name under Turkish locales. It becomes an ASCII-safe composition on `Psr7\Utils::asciiToUpper()`, and `AGENTS.md` gains the bullet mandating the locale-independent helpers. Needs guzzle/psr7#851 merged before CI can pass; no changelog per the major-merge flow.