### PR TITLE
Capitalize magic command names with ASCII folding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.3 - Upcoming
 
 * Normalize operation HTTP methods with locale-independent ASCII uppercasing
+* Capitalize magic command names with locale-independent ASCII folding
 
 ## 1.7.2 - 2026-07-08
 

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -70,7 +70,7 @@ class GuzzleClient extends ServiceClient
     public function getCommand($name, array $args = [])
     {
         if (!$this->description->hasOperation($name)) {
-            $name = ucfirst($name);
+            $name = $name === '' ? '' : strtr($name[0], 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ').substr($name, 1);
             if (!$this->description->hasOperation($name)) {
                 throw new \InvalidArgumentException(
                     "No operation found named {$name}"


### PR DESCRIPTION
`GuzzleClient::getCommand()` capitalizes command names with `ucfirst()`, which is locale-sensitive before PHP 8.2 like the rest of the case-function family, so a command name starting with `i` resolves to a corrupted operation name under single-byte locales such as Turkish. The first character is now folded with the locale-independent inline `strtr()` ASCII map, matching the 1.7.3 treatment of HTTP method casing; guzzle-services 2.0 receives the same fix through the psr7 helpers in guzzle/guzzle-services#301.