### PR TITLE
Adopt the psr7 asciiUcFirst helper

### DIFF
--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -87,7 +87,7 @@ class GuzzleClient extends ServiceClient
     public function getCommand(string $name, array $args = []): CommandInterface
     {
         if (!$this->description->hasOperation($name)) {
-            $name = $name === '' ? '' : Utils::asciiToUpper($name[0]).substr($name, 1);
+            $name = Utils::asciiUcFirst($name);
             if (!$this->description->hasOperation($name)) {
                 throw new \InvalidArgumentException(
                     "No operation found named {$name}"


### PR DESCRIPTION
The magic command name capitalization in `GuzzleClient::getCommand()` becomes a single `Psr7\Utils::asciiUcFirst()` call, replacing the hand-rolled composition and its empty-string guard with the helper that now owns both. Needs the psr7 3.0 asciiUcFirst PR merged before CI can pass.