### PR TITLE
Adopt the psr7 ASCII case folding helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## 1.7.3 - Upcoming
 
+* Require `guzzlehttp/psr7` ^2.13
 * Normalize operation HTTP methods with locale-independent ASCII uppercasing
 * Capitalize magic command names with locale-independent ASCII folding
+* Use the psr7 ASCII case folding helpers
 
 ## 1.7.2 - 2026-07-08
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^7.2.5 || ^8.0",
         "guzzlehttp/command": "^1.5.2",
         "guzzlehttp/guzzle": "^7.13.3",
-        "guzzlehttp/psr7": "^2.12.4",
+        "guzzlehttp/psr7": "^2.13@dev",
         "guzzlehttp/uri-template": "^1.0.9",
         "symfony/deprecation-contracts": "^2.5 || ^3.0",
         "symfony/polyfill-php80": "^1.25"

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Command\Guzzle\Handler\ValidatedDescriptionHandler;
 use GuzzleHttp\Command\Guzzle\ResponseLocation\ResponseLocationInterface;
 use GuzzleHttp\Command\ServiceClient;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Utils;
 
 /**
  * Default Guzzle web service client implementation.
@@ -70,7 +71,7 @@ class GuzzleClient extends ServiceClient
     public function getCommand($name, array $args = [])
     {
         if (!$this->description->hasOperation($name)) {
-            $name = $name === '' ? '' : strtr($name[0], 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ').substr($name, 1);
+            $name = Utils::asciiUcFirst($name);
             if (!$this->description->hasOperation($name)) {
                 throw new \InvalidArgumentException(
                     "No operation found named {$name}"

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Command\Guzzle\RequestLocation\XmlLocation;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\UriResolver;
+use GuzzleHttp\Psr7\Utils;
 use GuzzleHttp\UriTemplate\UriTemplate;
 use Psr\Http\Message\RequestInterface;
 
@@ -138,7 +139,7 @@ class Serializer
             /** @var mixed $method */
             $method = $operation->getHttpMethod() ?: 'GET';
             if (is_string($method)) {
-                $normalizedMethod = strtr($method, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+                $normalizedMethod = Utils::asciiToUpper($method);
                 if ($method !== $normalizedMethod) {
                     \trigger_deprecation(
                         'guzzlehttp/guzzle-services',
@@ -186,7 +187,7 @@ class Serializer
         /** @var mixed $method */
         $method = $operation->getHttpMethod() ?: 'GET';
         if (is_string($method)) {
-            $normalizedMethod = strtr($method, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+            $normalizedMethod = Utils::asciiToUpper($method);
             if ($method !== $normalizedMethod) {
                 \trigger_deprecation(
                     'guzzlehttp/guzzle-services',


### PR DESCRIPTION
This bumps the psr7 floor to `^2.13@dev` for now, until 2.13.0 is tagged, and converts the three 1.7.3 inline folds to the helpers: both `Serializer` method normalizations become `Utils::asciiToUpper()` and the magic command name capitalization in `GuzzleClient` becomes `Utils::asciiUcFirst()`. Behavior is unchanged from the inline folds; this aligns the 1.7 line with the helper-based 2.0. Needs guzzle/psr7#854 merged before CI can pass.