### PR TITLE
Drop redundant case folding helpers changelog note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 * Require `guzzlehttp/psr7` ^2.13
 * Normalize operation HTTP methods with locale-independent ASCII uppercasing
 * Capitalize magic command names with locale-independent ASCII folding
-* Use the psr7 ASCII case folding helpers
 
 ## 1.7.2 - 2026-07-08
 


### PR DESCRIPTION
The 1.7.3 `Require `guzzlehttp/psr7` ^2.13` bullet already accounts for the psr7 floor bump, and the two ASCII folding bullets above it describe the user-visible behavior; the separate "Use the psr7 ASCII case folding helpers" line only restated the internal refactor those bullets already cover, so it is dropped.