### PR TITLE
Replace deprecated Guzzle JSON utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.3 - Upcoming
 
 * Require `guzzlehttp/psr7` ^2.13
+* Replace deprecated Guzzle JSON utility methods with native JSON functions
 * Normalize operation HTTP methods with locale-independent ASCII uppercasing
 * Capitalize magic command names with locale-independent ASCII folding
 

--- a/src/RequestLocation/JsonLocation.php
+++ b/src/RequestLocation/JsonLocation.php
@@ -5,8 +5,8 @@ namespace GuzzleHttp\Command\Guzzle\RequestLocation;
 use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
+use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\Utils;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 
@@ -45,7 +45,7 @@ class JsonLocation extends AbstractLocation
             $param
         );
 
-        return $request->withBody(Psr7\Utils::streamFor(Utils::jsonEncode($this->jsonData)));
+        return $request->withBody(Psr7\Utils::streamFor(self::encodeJson($this->jsonData)));
     }
 
     /**
@@ -74,6 +74,21 @@ class JsonLocation extends AbstractLocation
             $request = $request->withHeader('Content-Type', $this->jsonContentType);
         }
 
-        return $request->withBody(Psr7\Utils::streamFor(Utils::jsonEncode($data)));
+        return $request->withBody(Psr7\Utils::streamFor(self::encodeJson($data)));
+    }
+
+    /**
+     * @param mixed $data
+     *
+     * @return string
+     */
+    private static function encodeJson($data)
+    {
+        $json = \json_encode($data);
+        if (\JSON_ERROR_NONE !== \json_last_error()) {
+            throw new InvalidArgumentException('json_encode error: '.\json_last_error_msg());
+        }
+
+        return $json;
     }
 }

--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -5,7 +5,7 @@ namespace GuzzleHttp\Command\Guzzle\ResponseLocation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Result;
 use GuzzleHttp\Command\ResultInterface;
-use GuzzleHttp\Utils;
+use GuzzleHttp\Exception\InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -36,7 +36,13 @@ class JsonLocation extends AbstractLocation
     ) {
         $body = (string) $response->getBody();
         $body = $body ?: '{}';
-        $this->json = Utils::jsonDecode($body, true);
+        $json = \json_decode($body, true);
+        if (\JSON_ERROR_NONE !== \json_last_error()) {
+            throw new InvalidArgumentException('json_decode error: '.\json_last_error_msg());
+        }
+
+        $this->json = $json;
+
         // relocate named arrays, so that they have the same structure as
         //  arrays nested in objects and visit can work on them in the same way
         if ($model->getType() === 'array' && ($name = $model->getName())) {

--- a/tests/GuzzleClientTest.php
+++ b/tests/GuzzleClientTest.php
@@ -12,7 +12,6 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Server\Server;
-use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -779,7 +778,7 @@ class GuzzleClientTest extends TestCase
     private function responseToResultTransformer()
     {
         return function (ResponseInterface $response, RequestInterface $request, CommandInterface $command) {
-            $data = Utils::jsonDecode($response->getBody(), true);
+            $data = \json_decode((string) $response->getBody(), true);
             parse_str($request->getBody(), $data['_request']);
 
             return new Result($data);

--- a/tests/RequestLocation/JsonLocationTest.php
+++ b/tests/RequestLocation/JsonLocationTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\RequestLocation\JsonLocation;
+use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
 
@@ -50,6 +51,20 @@ class JsonLocationTest extends TestCase
         $request = $location->after($command, $request, $operation);
         $this->assertEquals('{"foo":"bar","baz":{"bam":[1]}}', $request->getBody()->getContents());
         $this->assertEquals([0 => 'foo'], $request->getHeader('Content-Type'));
+    }
+
+    public function testPreservesJsonEncodingException()
+    {
+        $location = new JsonLocation();
+        $command = new Command('foo', ['foo' => "\xB1\x31"]);
+
+        try {
+            $location->visit($command, new Request('POST', 'http://httbin.org'), new Parameter(['name' => 'foo']));
+            $this->fail('Expected InvalidArgumentException was not thrown');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringStartsWith('json_encode error:', $e->getMessage());
+            $this->assertNull($e->getPrevious());
+        }
     }
 
     /**

--- a/tests/ResponseLocation/JsonLocationTest.php
+++ b/tests/ResponseLocation/JsonLocationTest.php
@@ -9,9 +9,9 @@ use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Guzzle\ResponseLocation\JsonLocation;
 use GuzzleHttp\Command\Result;
 use GuzzleHttp\Command\ResultInterface;
+use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -49,7 +49,7 @@ class JsonLocationTest extends TestCase
     public function testVisitsWiredArray()
     {
         $json = ['car_models' => ['ferrari', 'aston martin']];
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -119,6 +119,19 @@ class JsonLocationTest extends TestCase
         $this->assertEquals([], $result->toArray());
     }
 
+    public function testPreservesJsonDecodingException()
+    {
+        $location = new JsonLocation();
+
+        try {
+            $location->before(new Result(), new Response(200, [], '{'), new Parameter());
+            $this->fail('Expected InvalidArgumentException was not thrown');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringStartsWith('json_decode error:', $e->getMessage());
+            $this->assertNull($e->getPrevious());
+        }
+    }
+
     public function jsonProvider()
     {
         return [
@@ -138,7 +151,7 @@ class JsonLocationTest extends TestCase
             ['foo' => 'bar'],
             ['baz' => 'bam'],
         ];
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -185,7 +198,7 @@ class JsonLocationTest extends TestCase
                 'baz',
             ],
         ];
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -326,7 +339,7 @@ class JsonLocationTest extends TestCase
             ],
             'baz' => 'boo',
         ];
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -361,7 +374,7 @@ class JsonLocationTest extends TestCase
             ],
         ];
 
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -421,7 +434,7 @@ class JsonLocationTest extends TestCase
             'link' => null,
         ];
 
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -465,7 +478,7 @@ class JsonLocationTest extends TestCase
             'extra' => 'value',
         ];
 
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -530,7 +543,7 @@ class JsonLocationTest extends TestCase
             ],
         ];
 
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -612,7 +625,7 @@ class JsonLocationTest extends TestCase
     {
         $json = json_decode('{"scalar":"foo","nested":[{"bar":123,"baz":false},{"bar":345,"baz":true},{"bar":678,"baz":true}]}');
 
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 


### PR DESCRIPTION
Guzzle 7.15 deprecates its generic JSON utility methods, but Guzzle Services still uses them in JSON request and response locations and test helpers. This inlines the existing PHP 7.2-compatible encoding and decoding checks, preserving the current `InvalidArgumentException` messages and chains while removing every dependency on the deprecated methods.