### PR TITLE
Use native JSON exceptions for JSON locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Allow operations to override response processing with the `process` operation option
 * Support JSON response fields with multiple allowed `type` values
 * Reject scalar top-level JSON response bodies
+* Let native `JsonException` report JSON location encoding and decoding failures
 * Require custom implementations and subclasses of public service APIs to match native method signatures
 * Require custom parameter filters and extension points to accept exact value types instead of relying on scalar coercion
 * Validate cast integer values against string enum, pattern, and length constraints

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -150,6 +150,13 @@ throw `RuntimeException`. For endpoints that intentionally return scalar JSON,
 disable response processing with `process: false` and read the raw PSR-7
 response from the result's `response` key.
 
+#### JSON Location Exceptions
+
+Malformed JSON responses and request values that cannot be encoded as JSON now
+throw native `JsonException` directly from their JSON locations. Guzzle Services
+1.x exposed `GuzzleHttp\Exception\InvalidArgumentException` from Guzzle's JSON
+utility methods.
+
 #### Null Schema Values
 
 Schema parameters with `type` set to `'null'` now match only actual `null`

--- a/src/RequestLocation/JsonLocation.php
+++ b/src/RequestLocation/JsonLocation.php
@@ -8,7 +8,6 @@ use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\Guzzle\Operation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -42,7 +41,7 @@ class JsonLocation extends AbstractLocation
             $param
         );
 
-        return $request->withBody(Psr7\Utils::streamFor(Utils::jsonEncode($this->jsonData)));
+        return $request->withBody(Psr7\Utils::streamFor(\json_encode($this->jsonData, \JSON_THROW_ON_ERROR)));
     }
 
     public function after(
@@ -68,6 +67,6 @@ class JsonLocation extends AbstractLocation
             $request = $request->withHeader('Content-Type', $this->jsonContentType);
         }
 
-        return $request->withBody(Psr7\Utils::streamFor(Utils::jsonEncode($data)));
+        return $request->withBody(Psr7\Utils::streamFor(\json_encode($data, \JSON_THROW_ON_ERROR)));
     }
 }

--- a/src/ResponseLocation/JsonLocation.php
+++ b/src/ResponseLocation/JsonLocation.php
@@ -7,7 +7,6 @@ namespace GuzzleHttp\Command\Guzzle\ResponseLocation;
 use GuzzleHttp\Command\Guzzle\Parameter;
 use GuzzleHttp\Command\Result;
 use GuzzleHttp\Command\ResultInterface;
-use GuzzleHttp\Utils;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -32,7 +31,7 @@ class JsonLocation extends AbstractLocation
         Parameter $model
     ): ResultInterface {
         $body = (string) $response->getBody();
-        $decoded = $body !== '' ? Utils::jsonDecode($body, true) : [];
+        $decoded = $body !== '' ? \json_decode($body, true, 512, \JSON_THROW_ON_ERROR) : [];
 
         if (!is_array($decoded)) {
             throw new \RuntimeException(\sprintf('JSON response body must be an object or array; got %s.', get_debug_type($decoded)));

--- a/tests/GuzzleClientTest.php
+++ b/tests/GuzzleClientTest.php
@@ -16,7 +16,6 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Server\Server;
-use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -890,7 +889,8 @@ class GuzzleClientTest extends TestCase
     private function responseToResultTransformer(): callable
     {
         return function (ResponseInterface $response, RequestInterface $request, CommandInterface $command): Result {
-            $data = Utils::jsonDecode((string) $response->getBody(), true);
+            /** @var array $data */
+            $data = \json_decode((string) $response->getBody(), true, 512, \JSON_THROW_ON_ERROR);
             parse_str((string) $request->getBody(), $data['_request']);
 
             return new Result($data);

--- a/tests/RequestLocation/JsonLocationTest.php
+++ b/tests/RequestLocation/JsonLocationTest.php
@@ -54,6 +54,16 @@ class JsonLocationTest extends TestCase
         $this->assertEquals([0 => 'foo'], $request->getHeader('Content-Type'));
     }
 
+    public function testThrowsNativeJsonEncodingException(): void
+    {
+        $location = new JsonLocation();
+        $command = new Command('foo', ['foo' => "\xB1\x31"]);
+
+        $this->expectException(\JsonException::class);
+
+        $location->visit($command, new Request('POST', 'http://httbin.org'), new Parameter(['name' => 'foo']));
+    }
+
     /**
      * @group RequestLocation
      */

--- a/tests/ResponseLocation/JsonLocationTest.php
+++ b/tests/ResponseLocation/JsonLocationTest.php
@@ -13,7 +13,6 @@ use GuzzleHttp\Command\Result;
 use GuzzleHttp\Command\ResultInterface;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -51,7 +50,7 @@ class JsonLocationTest extends TestCase
     public function testVisitsWiredArray(): void
     {
         $json = ['car_models' => ['ferrari', 'aston martin']];
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json, \JSON_THROW_ON_ERROR);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -121,6 +120,15 @@ class JsonLocationTest extends TestCase
         $this->assertEquals([], $result->toArray());
     }
 
+    public function testThrowsNativeJsonDecodingException(): void
+    {
+        $location = new JsonLocation();
+
+        $this->expectException(\JsonException::class);
+
+        $location->before(new Result(), new Response(200, [], '{'), new Parameter());
+    }
+
     public static function scalarJsonResponseBodyProvider(): array
     {
         return [
@@ -166,7 +174,7 @@ class JsonLocationTest extends TestCase
             ['foo' => 'bar'],
             ['baz' => 'bam'],
         ];
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json, \JSON_THROW_ON_ERROR);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -213,7 +221,7 @@ class JsonLocationTest extends TestCase
                 'baz',
             ],
         ];
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json, \JSON_THROW_ON_ERROR);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -354,7 +362,7 @@ class JsonLocationTest extends TestCase
             ],
             'baz' => 'boo',
         ];
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json, \JSON_THROW_ON_ERROR);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -389,7 +397,7 @@ class JsonLocationTest extends TestCase
             ],
         ];
 
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json, \JSON_THROW_ON_ERROR);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -449,7 +457,7 @@ class JsonLocationTest extends TestCase
             'link' => null,
         ];
 
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json, \JSON_THROW_ON_ERROR);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -493,7 +501,7 @@ class JsonLocationTest extends TestCase
             'extra' => 'value',
         ];
 
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json, \JSON_THROW_ON_ERROR);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -583,7 +591,7 @@ class JsonLocationTest extends TestCase
      */
     public function testVisitsJsonPropertiesWithMultipleTypes(array $allowedTypes, array $json, array $expected): void
     {
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json, \JSON_THROW_ON_ERROR);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -641,7 +649,7 @@ class JsonLocationTest extends TestCase
             ],
         ];
 
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json, \JSON_THROW_ON_ERROR);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -711,7 +719,7 @@ class JsonLocationTest extends TestCase
             ],
         ];
 
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json, \JSON_THROW_ON_ERROR);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 
@@ -791,9 +799,9 @@ class JsonLocationTest extends TestCase
      */
     public function testVisitsNestedArrayOfObjects(): void
     {
-        $json = json_decode('{"scalar":"foo","nested":[{"bar":123,"baz":false},{"bar":345,"baz":true},{"bar":678,"baz":true}]}');
+        $json = \json_decode('{"scalar":"foo","nested":[{"bar":123,"baz":false},{"bar":345,"baz":true},{"bar":678,"baz":true}]}', false, 512, \JSON_THROW_ON_ERROR);
 
-        $body = Utils::jsonEncode($json);
+        $body = \json_encode($json, \JSON_THROW_ON_ERROR);
         $response = new Response(200, ['Content-Type' => 'application/json'], $body);
         $mock = new MockHandler([$response]);
 


### PR DESCRIPTION
Guzzle 8 removes its generic JSON utilities, so Guzzle Services 2.0 must own its JSON serialization behavior. This uses PHP’s native JSON functions with `JSON_THROW_ON_ERROR` in request and response locations and lets `JsonException` surface directly, giving both directions one simple native contract while retaining the separate `RuntimeException` for valid scalar response bodies.