### PR TITLE
Escape unsafe service exception diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@
 - Handle `preg_*` engine failures: when the result is used as data, test for
   `false` or `null` and throw a `\RuntimeException` including
   `preg_last_error_msg()`; boolean validation guards must compare strictly, such
-  as `=== 1`, so an engine failure can only ever fail closed.
+  as `=== 1`, so an engine failure can only ever fail closed. Diagnostic
+  escaping is the narrow exception: use a deterministic bytewise fallback rather
+  than throwing, so it cannot obscure the original exception.
 - Anchor validation patterns to the true end of input with the `D` modifier or
   `\z`; a bare `$` accepts a trailing newline.
 - Never embed raw control bytes in exception messages and other diagnostics;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Support JSON response fields with multiple allowed `type` values
 * Reject scalar top-level JSON response bodies
 * Let native `JsonException` report JSON location encoding and decoding failures
+* Escape unsafe service metadata and response values in generated exceptions
 * Require custom implementations and subclasses of public service APIs to match native method signatures
 * Require custom parameter filters and extension points to accept exact value types instead of relying on scalar coercion
 * Validate cast integer values against string enum, pattern, and length constraints

--- a/src/Description.php
+++ b/src/Description.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Command\Guzzle;
 
+use GuzzleHttp\Psr7\DiagnosticValue;
 use GuzzleHttp\Psr7\Uri;
 
 /**
@@ -93,7 +94,7 @@ class Description implements DescriptionInterface
         if (isset($config['operations'])) {
             foreach ($config['operations'] as $name => $operation) {
                 if (!is_array($operation)) {
-                    throw new \InvalidArgumentException(\sprintf('Operation "%s" must be an array; got %s.', (string) $name, get_debug_type($operation)));
+                    throw new \InvalidArgumentException(\sprintf('Operation "%s" must be an array; got %s.', DiagnosticValue::escape((string) $name), get_debug_type($operation)));
                 }
                 $this->operations[$name] = $operation;
             }
@@ -155,7 +156,7 @@ class Description implements DescriptionInterface
     public function getOperation(string $name): Operation
     {
         if (!$this->hasOperation($name)) {
-            throw new \InvalidArgumentException("No operation found named $name");
+            throw new \InvalidArgumentException(\sprintf('No operation found named %s', DiagnosticValue::escape($name)));
         }
 
         // Lazily create operations as they are retrieved
@@ -177,7 +178,7 @@ class Description implements DescriptionInterface
     public function getModel(string $id): Parameter
     {
         if (!$this->hasModel($id)) {
-            throw new \InvalidArgumentException("No model found named $id");
+            throw new \InvalidArgumentException(\sprintf('No model found named %s', DiagnosticValue::escape($id)));
         }
 
         // Lazily create models as they are retrieved

--- a/src/Deserializer.php
+++ b/src/Deserializer.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Command\Guzzle\ResponseLocation\StatusCodeLocation;
 use GuzzleHttp\Command\Guzzle\ResponseLocation\XmlLocation;
 use GuzzleHttp\Command\Result;
 use GuzzleHttp\Command\ResultInterface;
+use GuzzleHttp\Psr7\DiagnosticValue;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -133,7 +134,7 @@ class Deserializer
         array &$context
     ): ResultInterface {
         if (!isset($this->responseLocations[$location])) {
-            throw new \RuntimeException("Unknown location: $location");
+            throw new \RuntimeException(\sprintf('Unknown location: %s', DiagnosticValue::escape($location)));
         }
 
         $context['visitors'][$location] = $this->responseLocations[$location];
@@ -257,7 +258,7 @@ class Deserializer
         }
 
         if (null !== $bestException) {
-            throw new $bestException($response->getReasonPhrase(), $command, null, $request, $response);
+            throw new $bestException(DiagnosticValue::escape($response->getReasonPhrase()), $command, null, $request, $response);
         }
 
         // If we reach here, no exception could be match from descriptor, and Guzzle exception will propagate if

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Command\ResultInterface;
 use GuzzleHttp\Command\ServiceClient;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\DiagnosticValue;
 use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -89,9 +90,7 @@ class GuzzleClient extends ServiceClient
         if (!$this->description->hasOperation($name)) {
             $name = Utils::asciiUcFirst($name);
             if (!$this->description->hasOperation($name)) {
-                throw new \InvalidArgumentException(
-                    "No operation found named {$name}"
-                );
+                throw new \InvalidArgumentException(\sprintf('No operation found named %s', DiagnosticValue::escape($name)));
             }
         }
 
@@ -222,7 +221,7 @@ class GuzzleClient extends ServiceClient
         throw new \InvalidArgumentException(\sprintf(
             'Passing %s to GuzzleClient config option "%s" is invalid; expected %s.',
             get_debug_type($value),
-            $option,
+            DiagnosticValue::escape($option),
             $expected
         ));
     }

--- a/src/Handler/ValidatedDescriptionHandler.php
+++ b/src/Handler/ValidatedDescriptionHandler.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Command\Guzzle\NonSerializableTrait;
 use GuzzleHttp\Command\Guzzle\SchemaValidator;
 use GuzzleHttp\Command\ResultInterface;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\DiagnosticValue;
 
 /**
  * Handler used to validate command input against a service description.
@@ -80,7 +81,11 @@ class ValidatedDescriptionHandler
             }
 
             if ($errors) {
-                throw new CommandException('Validation errors: '.implode("\n", $errors), $command);
+                $diagnosticErrors = array_map(static function (string $error): string {
+                    return DiagnosticValue::escape($error);
+                }, $errors);
+
+                throw new CommandException(\sprintf('Validation errors: %s', implode('; ', $diagnosticErrors)), $command);
             }
 
             return $handler($command);

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Command\Guzzle;
 
 use GuzzleHttp\Command\ToArrayInterface;
+use GuzzleHttp\Psr7\DiagnosticValue;
 
 /**
  * Guzzle operation
@@ -274,7 +275,7 @@ class Operation implements ToArrayInterface
     private function resolveExtends(string $name, array $config): array
     {
         if (!$this->description->hasOperation($name)) {
-            throw new \InvalidArgumentException('No operation named '.$name);
+            throw new \InvalidArgumentException(\sprintf('No operation named %s', DiagnosticValue::escape($name)));
         }
 
         // Merge parameters together one level deep
@@ -299,8 +300,8 @@ class Operation implements ToArrayInterface
                 throw new \InvalidArgumentException(\sprintf(
                     'Passing %s as operation parameter "%s.%s" is invalid; expected array.',
                     get_debug_type($param),
-                    $this->config['name'],
-                    $name
+                    DiagnosticValue::escape((string) $this->config['name']),
+                    DiagnosticValue::escape((string) $name)
                 ));
             }
             $param['name'] = $name;

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Command\Guzzle\RequestLocation\MultiPartLocation;
 use GuzzleHttp\Command\Guzzle\RequestLocation\QueryLocation;
 use GuzzleHttp\Command\Guzzle\RequestLocation\RequestLocationInterface;
 use GuzzleHttp\Command\Guzzle\RequestLocation\XmlLocation;
+use GuzzleHttp\Psr7\DiagnosticValue;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\UriResolver;
@@ -95,7 +96,7 @@ class Serializer
                 continue;
             }
             if (!isset($this->locations[$location])) {
-                throw new \RuntimeException("No location registered for $name");
+                throw new \RuntimeException(\sprintf('No location registered for %s', DiagnosticValue::escape((string) $name)));
             }
             $visitedLocations[$location] = true;
             $request = $this->locations[$location]->visit($command, $request, $param);

--- a/tests/DescriptionTest.php
+++ b/tests/DescriptionTest.php
@@ -126,6 +126,16 @@ class DescriptionTest extends TestCase
         ]);
     }
 
+    public function testEscapesUnsafeOperationNamesInDescriptionErrors(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Operation "bad\\xFF" must be an array; got stdClass.');
+
+        new Description([
+            'operations' => ["bad\xFF" => new \stdClass()],
+        ]);
+    }
+
     public function testDoesNotUseLegacyBaseUrl(): void
     {
         $description = new Description(['baseUrl' => 'http://foo.com']);

--- a/tests/DeserializerTest.php
+++ b/tests/DeserializerTest.php
@@ -280,8 +280,8 @@ class DeserializerTest extends TestCase
 
     public function testCreateExceptionWithExactMatchOfReasonPhrase(): void
     {
-        $this->expectException(CustomCommandException::class);
-        $response = new Response(404, [], null, '1.1', 'Bar');
+        $reasonPhrase = "Bad \u{0080}";
+        $response = new Response(404, [], null, '1.1', $reasonPhrase);
         $mock = new MockHandler([$response]);
 
         $description = new Description([
@@ -301,7 +301,7 @@ class DeserializerTest extends TestCase
                         ],
                     ],
                     'errorResponses' => [
-                        ['code' => 404, 'phrase' => 'Bar', 'class' => CustomCommandException::class],
+                        ['code' => 404, 'phrase' => $reasonPhrase, 'class' => CustomCommandException::class],
                     ],
                 ],
             ],
@@ -317,7 +317,13 @@ class DeserializerTest extends TestCase
 
         $httpClient = new HttpClient(['handler' => $mock]);
         $client = new GuzzleClient($httpClient, $description);
-        $client->foo(['bar' => 'baz']);
+        try {
+            $client->foo(['bar' => 'baz']);
+            self::fail('Expected a custom command exception.');
+        } catch (CustomCommandException $e) {
+            self::assertSame('Bad \\x80', $e->getMessage());
+            self::assertSame($response, $e->getResponse());
+        }
     }
 
     public function testFavourMostPreciseMatch(): void

--- a/tests/Handler/ValidatedDescriptionHandlerTest.php
+++ b/tests/Handler/ValidatedDescriptionHandlerTest.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 namespace GuzzleHttp\Tests\Command\Guzzle\Handler;
 
 use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Command\Command;
+use GuzzleHttp\Command\CommandInterface;
+use GuzzleHttp\Command\Exception\CommandException;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
+use GuzzleHttp\Command\Guzzle\Handler\ValidatedDescriptionHandler;
+use GuzzleHttp\Command\Guzzle\SchemaValidator;
 use GuzzleHttp\Command\Result;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Server\Server;
 use PHPUnit\Framework\TestCase;
@@ -20,7 +26,7 @@ class ValidatedDescriptionHandlerTest extends TestCase
     public function testValidates(): void
     {
         $this->expectExceptionMessage('Validation errors: [bar] is a required string');
-        $this->expectException(\GuzzleHttp\Command\Exception\CommandException::class);
+        $this->expectException(CommandException::class);
         $description = new Description([
             'operations' => [
                 'foo' => [
@@ -69,7 +75,7 @@ class ValidatedDescriptionHandlerTest extends TestCase
     public function testValidatesAdditionalParameters(): void
     {
         $this->expectExceptionMessage('Validation errors: [bar] must be of type string');
-        $this->expectException(\GuzzleHttp\Command\Exception\CommandException::class);
+        $this->expectException(CommandException::class);
         $description = new Description([
             'operations' => [
                 'foo' => [
@@ -90,6 +96,40 @@ class ValidatedDescriptionHandlerTest extends TestCase
 
         $client = new GuzzleClient(new HttpClient(), $description);
         $client->foo(['bar' => new \stdClass()]);
+    }
+
+    public function testEscapesCompleteValidationErrorsAtExceptionBoundary(): void
+    {
+        $validator = new SchemaValidator();
+        $description = new Description([
+            'operations' => [
+                'foo' => [
+                    'parameters' => [
+                        "bad\0" => [
+                            'type' => 'string',
+                            'required' => true,
+                        ],
+                        "worse\n" => [
+                            'type' => 'string',
+                            'required' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $handler = new ValidatedDescriptionHandler($description, $validator);
+        $command = new Command('foo');
+
+        try {
+            $handler(static function (CommandInterface $command): PromiseInterface {
+                self::fail('Validation should fail before the next handler is called.');
+            })($command);
+            self::fail('Expected a command exception.');
+        } catch (CommandException $e) {
+            self::assertSame('Validation errors: [bad\\x00] is a required string; [worse\\x0A] is a required string', $e->getMessage());
+            self::assertSame(["[worse\n] is a required string"], $validator->getErrors());
+            self::assertSame($command, $e->getCommand());
+        }
     }
 
     public function testFilterBeforeValidate(): void


### PR DESCRIPTION
Guzzle Services 2 copies service metadata, validation errors, and remote reason phrases into generated exceptions. This uses the PSR-7 diagnostic helper at those boundaries, including after a complete validation error is composed, while preserving raw descriptions, validation results, commands, and responses.