### PR TITLE
Add PHP 8.6 to the CI matrix and version guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6']
 
     steps:
       - name: Set up PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.1 - Upcoming
 
-* Add PHP 8.6 to the supported and tested versions
+* Add support for PHP 8.6
 
 ## 2.0.0 - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.0.1 - Upcoming
+
+* Add PHP 8.6 to the supported and tested versions
+
 ## 2.0.0 - 2026-07-20
 
 * Drop support for PHP 7.2 and 7.3

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ composer require guzzlehttp/guzzle-services
 
 | Version | Status       | PHP Version  |
 |---------|--------------|--------------|
-| 2.0     | Latest       | >=7.4,<8.6   |
-| 1.7     | Maintenance  | >=7.2.5,<8.6 |
+| 2.0     | Latest       | >=7.4,<8.7   |
+| 1.7     | Maintenance  | >=7.2.5,<8.7 |
 
 ## Quick Start
 


### PR DESCRIPTION
The full test suite passes under PHP 8.6.0beta1 without code changes, so this adds PHP 8.6 to the CI matrix and version guidance.
